### PR TITLE
RANCHER-716 Switch off cloudwatch log group

### DIFF
--- a/pipelines/rancher/cluster.groovy
+++ b/pipelines/rancher/cluster.groovy
@@ -98,7 +98,13 @@ ansiColor('xterm') {
                         terraform.tfApply(tfWorkDir)
                     } else if (params.action == 'destroy') {
                         input message: "Are you shure that you want to destroy ${cluster_name} cluster?"
-                        terraform.tfRemoveElastic(tfWorkDir)
+                        try {
+                            terraform.tfRemoveElastic(tfWorkDir)
+                        }
+                        catch (exception)
+                        {
+                            println(exception)
+                        }
                         terraform.tfDestroy(tfWorkDir, tfVars)
                     }
                 }

--- a/terraform/rancher/cluster/eks.tf
+++ b/terraform/rancher/cluster/eks.tf
@@ -30,6 +30,9 @@ locals {
 module "eks_cluster" {
   source  = "terraform-aws-modules/eks/aws"
   version = "18.30.2"
+  # Switch off cloudwatch log group
+  create_cloudwatch_log_group = false
+  cluster_enabled_log_types = []
 
   cluster_name      = terraform.workspace
   cluster_version   = "1.21" //For kube-poxy metrics 1.22 version needed


### PR DESCRIPTION
Added next lines for turn off cloudwatch log:
create_cloudwatch_log_group = false
cluster_enabled_log_types = []

And added try/catch for function terraform.tfRemoveElastic(tfWorkDir) because very often we getting errors here when destroy failed in middle because some ingress can't be deleted automaicaly 