### PR TITLE
FAT-5384: Java 17 for Karate Tests

### DIFF
--- a/vars/karateFlow.groovy
+++ b/vars/karateFlow.groovy
@@ -33,7 +33,7 @@ def call(params) {
     stage('Run karate tests') {
         script {
             def karateEnvironment = "folio-testing-karate"
-            withMaven(jdk: 'openjdk-11-jenkins-slave-all',
+            withMaven(jdk: 'openjdk-17-jenkins-slave-all',
                 maven: 'maven3-jenkins-slave-all',
                 mavenSettingsConfig: 'folioci-maven-settings') {
                 def modules = ""


### PR DESCRIPTION
https://issues.folio.org/browse/FAT-5384

Otherwise we get

```
[ERROR] Failed to execute goal org.apache.maven.plugins:maven-compiler-plugin:3.1:compile (default-compile) on project testrail-integration: Fatal error compiling: error: invalid target release: 17 -> [Help 1]
[ERROR] Failed to execute goal org.apache.maven.plugins:maven-compiler-plugin:3.1:testCompile (default-testCompile) on project mod-oai-pmh: Fatal error compiling: error: invalid target release: 17 -> [Help 1]
```