### PR TITLE
Fix createConfigMap function

### DIFF
--- a/vars/kubectl.groovy
+++ b/vars/kubectl.groovy
@@ -2,10 +2,8 @@ def createConfigMap(String name, String namespace, files) {
     try {
         def fromFileArgs = []
         switch (files) {
-            case String:
-                fromFileArgs.add("--from-file=${files}")
-                break
             case GString:
+            case String:
                 fromFileArgs.add("--from-file=${files}")
                 break
             case List:

--- a/vars/kubectl.groovy
+++ b/vars/kubectl.groovy
@@ -5,6 +5,9 @@ def createConfigMap(String name, String namespace, files) {
             case String:
                 fromFileArgs.add("--from-file=${files}")
                 break
+            case GString:
+                fromFileArgs.add("--from-file=${files}")
+                break
             case List:
                 fromFileArgs = files.collect { "--from-file=${it}" }
                 break

--- a/vars/kubectl.groovy
+++ b/vars/kubectl.groovy
@@ -94,6 +94,9 @@ def patchConfigMap(String name, String namespace, files) {
             case String:
                 fromFileArgs.add("--from-file=${files}")
                 break
+            case GString:
+                fromFileArgs.add("--from-file=${files}")
+                break
             case List:
                 fromFileArgs = files.collect { "--from-file=${it}" }
                 break

--- a/vars/kubectl.groovy
+++ b/vars/kubectl.groovy
@@ -89,10 +89,8 @@ def patchConfigMap(String name, String namespace, files) {
     try {
         def fromFileArgs = []
         switch (files) {
-            case String:
-                fromFileArgs.add("--from-file=${files}")
-                break
             case GString:
+            case String:
                 fromFileArgs.add("--from-file=${files}")
                 break
             case List:


### PR DESCRIPTION
see job run: https://jenkins-aws.indexdata.com/job/Rancher/job/vasili-workflow/job/fix-createconfigmap/8/console
some logs
`+ kubectl create configmap edge-inn-reach-ephemeral-properties '--namespace=rtr' '--from-file=./edge-inn-reach-ephemeral-properties' --save-config
configmap/edge-inn-reach-ephemeral-properties created
[Pipeline] sh
+ kubectl create configmap edge-rtac-ephemeral-properties '--namespace=rtr' '--from-file=./edge-rtac-ephemeral-properties' --save-config
configmap/edge-rtac-ephemeral-properties created
[Pipeline] sh
+ kubectl create configmap edge-oai-pmh-ephemeral-properties '--namespace=rtr' '--from-file=./edge-oai-pmh-ephemeral-properties' --save-config
configmap/edge-oai-pmh-ephemeral-properties created
[Pipeline] sh
+ kubectl create configmap edge-connexion-ephemeral-properties '--namespace=rtr' '--from-file=./edge-connexion-ephemeral-properties' --save-config
configmap/edge-connexion-ephemeral-properties created
[Pipeline] sh
+ kubectl create configmap edge-sip2-ephemeral-properties '--namespace=rtr' '--from-file=./edge-sip2-ephemeral-properties' --save-config
configmap/edge-sip2-ephemeral-properties created
[Pipeline] sh
+ kubectl create configmap edge-ncip-ephemeral-properties '--namespace=rtr' '--from-file=./edge-ncip-ephemeral-properties' --save-config
configmap/edge-ncip-ephemeral-properties created
[Pipeline] sh
+ kubectl create configmap edge-patron-ephemeral-properties '--namespace=rtr' '--from-file=./edge-patron-ephemeral-properties' --save-config
configmap/edge-patron-ephemeral-properties created
[Pipeline] sh
+ kubectl create configmap edge-orders-ephemeral-properties '--namespace=rtr' '--from-file=./edge-orders-ephemeral-properties' --save-config
configmap/edge-orders-ephemeral-properties created
[Pipeline] sh
+ kubectl create configmap edge-caiasoft-ephemeral-properties '--namespace=rtr' '--from-file=./edge-caiasoft-ephemeral-properties' --save-config
configmap/edge-caiasoft-ephemeral-properties created
[Pipeline] sh
+ kubectl create configmap edge-dematic-ephemeral-properties '--namespace=rtr' '--from-file=./edge-dematic-ephemeral-properties' --save-config
configmap/edge-dematic-ephemeral-properties created`

#######
also see https://jenkins-aws.indexdata.com/job/Rancher/job/vasili-workflow/job/fix-createconfigmap/6/console

with mockserver configmap creation

+ kubectl get configmap mockserver-config -n test
Error from server (NotFound): configmaps "mockserver-config" not found
[Pipeline] sh
+ kubectl create configmap mockserver-config '--namespace=test' '--from-file=./initializerJson.json' '--from-file=./mockserver.properties' --save-config
configmap/mockserver-config created