### PR TITLE
increase memory limit for the mod-pubsub module pod

### DIFF
--- a/resources/helm/development.yaml
+++ b/resources/helm/development.yaml
@@ -840,7 +840,7 @@ mod-pubsub:
   replicaCount: 1
   resources:
     limits:
-      memory: '1024Mi'
+      memory: '1536Mi'
     requests:
       memory: '768Mi'
 mod-quick-marc:


### PR DESCRIPTION
increase memory limit for the mod-pubsub module pod. was 1gb now 1.5 gb