### PR TITLE
RANCHER-1082 Okapi-token-with-expiry.

### DIFF
--- a/src/org/folio/rest_v2/Authorization.groovy
+++ b/src/org/folio/rest_v2/Authorization.groovy
@@ -61,16 +61,18 @@ class Authorization extends Common {
   String getToken(OkapiTenant tenant) {
     getDefaultHeaders(tenant) + ["X-Okapi-Token": getOkapiToken(tenant)]
   }
+
   /**
-  * Gets the token with expiry for the specified tenant.
-  *
-  * @param tenant The tenant for which to get the token.
-  * @return token with headers.
-  */
+   * Gets the token with expiry for the specified tenant.
+   *
+   * @param tenant The tenant for which to get the token.
+   * @return token with headers.
+   */
   String getTokenWithExpiry(OkapiTenant tenant) {
     //TODO Need to test an ability to use X-OkapiToken header with new endpoint. RANCHER-1082
     getDefaultHeaders(tenant) + ["X-Okapi-Token": getOkapiTokenWithExpiry(tenant)]
   }
+
   /**
    * Checks if the user credentials exist for the specified tenant.
    *

--- a/src/org/folio/rest_v2/Authorization.groovy
+++ b/src/org/folio/rest_v2/Authorization.groovy
@@ -69,7 +69,7 @@ class Authorization extends Common {
    * @return token with headers.
    */
   String getTokenWithExpiry(OkapiTenant tenant) {
-    //TODO Need to test an ability to use X-OkapiToken header with new endpoint. RANCHER-1082
+    //TODO Need to test an ability to use X-Okapi-Token header with new endpoint. RANCHER-1082
     getDefaultHeaders(tenant) + ["X-Okapi-Token": getOkapiTokenWithExpiry(tenant)]
   }
 

--- a/src/org/folio/rest_v2/Authorization.groovy
+++ b/src/org/folio/rest_v2/Authorization.groovy
@@ -53,7 +53,7 @@ class Authorization extends Common {
   }
 
   /**
-   * Gets the token with expiry for the specified tenant.
+   * Gets the token for the specified tenant.
    *
    * @param tenant The tenant for which to get the token.
    * @return token with headers.
@@ -61,7 +61,16 @@ class Authorization extends Common {
   String getToken(OkapiTenant tenant) {
     getDefaultHeaders(tenant) + ["X-Okapi-Token": getOkapiToken(tenant)]
   }
-
+  /**
+  * Gets the token with expiry for the specified tenant.
+  *
+  * @param tenant The tenant for which to get the token.
+  * @return token with headers.
+  */
+  String getTokenWithExpiry(OkapiTenant tenant) {
+    //TODO Need to test an ability to use X-OkapiToken header with new endpoint. RANCHER-1082
+    getDefaultHeaders(tenant) + ["X-Okapi-Token": getOkapiTokenWithExpiry(tenant)]
+  }
   /**
    * Checks if the user credentials exist for the specified tenant.
    *

--- a/src/org/folio/rest_v2/Authorization.groovy
+++ b/src/org/folio/rest_v2/Authorization.groovy
@@ -1,5 +1,6 @@
 package org.folio.rest_v2
 
+import groovy.json.JsonOutput
 import org.folio.models.OkapiUser
 import org.folio.models.OkapiTenant
 import org.folio.utilities.RequestException
@@ -11,142 +12,187 @@ import org.folio.utilities.RequestException
  */
 class Authorization extends Common {
 
-    /**
-     * Initializes a new instance of the Authorization class.
-     *
-     * @param context The current context.
-     * @param okapiDomain The domain for Okapi.
-     * @param debug Debug flag indicating whether debugging is enabled.
-     */
-    Authorization(Object context, String okapiDomain, boolean debug = false) {
-        super(context, okapiDomain, debug)
+  /**
+   * Initializes a new instance of the Authorization class.
+   *
+   * @param context The current context.
+   * @param okapiDomain The domain for Okapi.
+   * @param debug Debug flag indicating whether debugging is enabled.
+   */
+  Authorization(Object context, String okapiDomain, boolean debug = false) {
+    super(context, okapiDomain, debug)
+  }
+
+  /**
+   * Generates a URL for the specified path.
+   *
+   * @param path The path for which to generate the URL.
+   * @return The generated URL.
+   */
+  String generateUrl(String path) {
+    "https://${okapiDomain}${path}"
+  }
+
+  /**
+   * Gets the default headers for the specified tenant.
+   *
+   * @param tenant The tenant for which to get the default headers.
+   * @return The default headers.
+   */
+  static Map<String, String> getDefaultHeaders(OkapiTenant tenant) {
+    return ["X-Okapi-Tenant": tenant.tenantId, "Content-Type": "application/json"]
+  }
+
+  /**
+   * Gets the authorized headers for the specified tenant.
+   *
+   * @param tenant The tenant for which to get the authorized headers.
+   * @return The authorized headers.
+   */
+  Map<String, String> getAuthorizedHeaders(OkapiTenant tenant) {
+    getDefaultHeaders(tenant) + ["X-Okapi-Token": getOkapiToken(tenant)]
+  }
+
+  /**
+   * Gets the token with expiry for the specified tenant.
+   *
+   * @param tenant The tenant for which to get the token.
+   * @return token with headers.
+   */
+  String getToken(OkapiTenant tenant) {
+    getDefaultHeaders(tenant) + ["X-Okapi-Token": getOkapiToken(tenant)]
+  }
+
+  /**
+   * Checks if the user credentials exist for the specified tenant.
+   *
+   * @param tenant The tenant for which to check the user credentials.
+   * @param user The user for which to check the credentials.
+   * @return True if the user credentials exist; false otherwise.
+   */
+  boolean checkUserCredentialsExist(OkapiTenant tenant, OkapiUser user) {
+    user.checkUuid()
+
+    String url = generateUrl("/authn/credentials-existence?userId=${user.uuid}")
+    Map<String, String> headers = getAuthorizedHeaders(tenant)
+
+    def response = restClient.get(url, headers).body
+
+    return response?.credentialsExist
+  }
+
+  /**
+   * Sets the user credentials for the specified tenant.
+   *
+   * @param tenant The tenant for which to set the user credentials.
+   * @param user The user for which to set the credentials.
+   */
+  void setUserCredentials(OkapiTenant tenant, OkapiUser user) {
+    if (checkUserCredentialsExist(tenant, user)) {
+      logger.warning("User credentials already exist for user (${user.username}). Skipping credentials creation.")
+      return
     }
 
-    /**
-     * Generates a URL for the specified path.
-     *
-     * @param path The path for which to generate the URL.
-     * @return The generated URL.
-     */
-    String generateUrl(String path) {
-        "https://${okapiDomain}${path}"
+    String url = generateUrl("/authn/credentials")
+    Map<String, String> headers = getAuthorizedHeaders(tenant)
+    Map<String, Object> body = [
+      "password": user.getPasswordPlainText(),
+      "userId"  : user.uuid
+    ]
+
+    restClient.post(url, body, headers)
+    logger.info("Credentials for user ${user.username} created successfully")
+  }
+
+  /**
+   * Logs in the user for the specified tenant.
+   *
+   * @param tenant The tenant for which to log in the user.
+   */
+  void loginUser(OkapiTenant tenant) {
+    String url = generateUrl("/bl-users/login")
+    Map<String, String> headers = getDefaultHeaders(tenant)
+    Map<String, String> body = [
+      "username": tenant.adminUser.username,
+      "password": tenant.adminUser.getPasswordPlainText()
+    ]
+
+    def response = restClient.post(url, body, headers)
+
+    if (response) {
+      tenant.adminUser.token = response.headers['X-Okapi-Token']
+      tenant.adminUser.uuid = response.body.user.id
+      tenant.adminUser.permissions = response.body.permissions.permissions
+      tenant.adminUser.permissionsId = response.body.permissions.permissionsId
+    }
+  }
+
+  /**
+   * Gets the Okapi token for the specified tenant.
+   *
+   * @param tenant The tenant for which to get the Okapi token.
+   * @return The Okapi token.
+   */
+  String getOkapiToken(OkapiTenant tenant) {
+    if (!tenant.adminUser) {
+      logger.warning("Admin user not set for ${tenant.tenantId}")
+      return
     }
 
-    /**
-     * Gets the default headers for the specified tenant.
-     *
-     * @param tenant The tenant for which to get the default headers.
-     * @return The default headers.
-     */
-    static Map<String, String> getDefaultHeaders(OkapiTenant tenant) {
-        return ["X-Okapi-Tenant": tenant.tenantId, "Content-Type": "application/json"]
+    String url = generateUrl("/authn/login")
+    Map<String, String> headers = getDefaultHeaders(tenant)
+    Map<String, String> body = [
+      "username": tenant.adminUser.username,
+      "password": tenant.adminUser.getPasswordPlainText()
+    ]
+
+    try {
+      def response = restClient.post(url, body, headers)
+
+      if (response) {
+        String token = response.headers['x-okapi-token'].join()
+        tenant.adminUser.token = token
+        return token
+      }
+    } catch (RequestException e) {
+      if (e.statusCode != HttpURLConnection.HTTP_NOT_FOUND && e.statusCode != HttpURLConnection.HTTP_BAD_REQUEST) {
+        throw new RequestException(e.getMessage(), e.statusCode)
+      }
+    }
+  }
+
+  /**
+   * Gets the Okapi token with expiry date for the specified tenant.
+   *
+   * @param tenant The tenant for which to get the Okapi token.
+   * @return The Okapi token with expiry.
+   */
+  String getOkapiTokenWithExpiry(OkapiTenant tenant) {
+    if (!tenant.adminUser) {
+      logger.warning("Admin user not set for ${tenant.tenantId}")
+      return
     }
 
-    /**
-     * Gets the authorized headers for the specified tenant.
-     *
-     * @param tenant The tenant for which to get the authorized headers.
-     * @return The authorized headers.
-     */
-    Map<String, String> getAuthorizedHeaders(OkapiTenant tenant) {
-        getDefaultHeaders(tenant) + ["X-Okapi-Token": getOkapiToken(tenant)]
+    String url = generateUrl("/bl-users/login-with-expiry?expandPermissions=true&fullPermissions=true")
+    Map<String, String> headers = getDefaultHeaders(tenant)
+    Map<String, String> body = [
+      "username": tenant.adminUser.username,
+      "password": tenant.adminUser.getPasswordPlainText()
+    ]
+
+    try {
+      def response = restClient.post(url, body, headers)
+      if (response) {
+        def token_data = response.headers['Set-Cookie'][1]
+        def token_draft = token_data.split("=")[1]
+        String token = token_draft.split(";")[0].join()
+        tenant.adminUser.token = token
+        return token
+      }
+    } catch (RequestException e) {
+      if (e.statusCode != HttpURLConnection.HTTP_NOT_FOUND && e.statusCode != HttpURLConnection.HTTP_BAD_REQUEST) {
+        throw new RequestException(e.getMessage(), e.statusCode)
+      }
     }
-
-    /**
-     * Checks if the user credentials exist for the specified tenant.
-     *
-     * @param tenant The tenant for which to check the user credentials.
-     * @param user The user for which to check the credentials.
-     * @return True if the user credentials exist; false otherwise.
-     */
-    boolean checkUserCredentialsExist(OkapiTenant tenant, OkapiUser user) {
-        user.checkUuid()
-
-        String url = generateUrl("/authn/credentials-existence?userId=${user.uuid}")
-        Map<String, String> headers = getAuthorizedHeaders(tenant)
-
-        def response = restClient.get(url, headers).body
-
-        return response?.credentialsExist
-    }
-
-    /**
-     * Sets the user credentials for the specified tenant.
-     *
-     * @param tenant The tenant for which to set the user credentials.
-     * @param user The user for which to set the credentials.
-     */
-    void setUserCredentials(OkapiTenant tenant, OkapiUser user) {
-        if (checkUserCredentialsExist(tenant, user)) {
-            logger.warning("User credentials already exist for user (${user.username}). Skipping credentials creation.")
-            return
-        }
-
-        String url = generateUrl("/authn/credentials")
-        Map<String, String> headers = getAuthorizedHeaders(tenant)
-        Map<String, Object> body = [
-            "password": user.getPasswordPlainText(),
-            "userId"  : user.uuid
-        ]
-
-        restClient.post(url, body, headers)
-        logger.info("Credentials for user ${user.username} created successfully")
-    }
-
-    /**
-     * Logs in the user for the specified tenant.
-     *
-     * @param tenant The tenant for which to log in the user.
-     */
-    void loginUser(OkapiTenant tenant) {
-        String url = generateUrl("/bl-users/login")
-        Map<String, String> headers = getDefaultHeaders(tenant)
-        Map<String, String> body = [
-            "username": tenant.adminUser.username,
-            "password": tenant.adminUser.getPasswordPlainText()
-        ]
-
-        def response = restClient.post(url, body, headers)
-
-        if (response) {
-            tenant.adminUser.token = response.headers['X-Okapi-Token']
-            tenant.adminUser.uuid = response.body.user.id
-            tenant.adminUser.permissions = response.body.permissions.permissions
-            tenant.adminUser.permissionsId = response.body.permissions.permissionsId
-        }
-    }
-
-    /**
-     * Gets the Okapi token for the specified tenant.
-     *
-     * @param tenant The tenant for which to get the Okapi token.
-     * @return The Okapi token.
-     */
-    String getOkapiToken(OkapiTenant tenant) {
-        if (!tenant.adminUser) {
-            logger.warning("Admin user not set for ${tenant.tenantId}")
-            return
-        }
-
-        String url = generateUrl("/authn/login")
-        Map<String, String> headers = getDefaultHeaders(tenant)
-        Map<String, String> body = [
-            "username": tenant.adminUser.username,
-            "password": tenant.adminUser.getPasswordPlainText()
-        ]
-
-        try {
-            def response = restClient.post(url, body, headers)
-
-            if (response) {
-                String token = response.headers['x-okapi-token'].join()
-                tenant.adminUser.token = token
-                return token
-            }
-        } catch (RequestException e) {
-            if (e.statusCode != HttpURLConnection.HTTP_NOT_FOUND && e.statusCode != HttpURLConnection.HTTP_BAD_REQUEST) {
-                throw new RequestException(e.getMessage(), e.statusCode)
-            }
-        }
-    }
+  }
 }

--- a/src/org/folio/rest_v2/Authorization.groovy
+++ b/src/org/folio/rest_v2/Authorization.groovy
@@ -1,6 +1,5 @@
 package org.folio.rest_v2
 
-import groovy.json.JsonOutput
 import org.folio.models.OkapiUser
 import org.folio.models.OkapiTenant
 import org.folio.utilities.RequestException


### PR DESCRIPTION
Testing part is done: https://jenkins-aws.indexdata.com/job/folioRancher/job/tmpFolderForDraftPipelines/job/jiraFlowRANCHER-927/105/console 
Almost the same function, just changed source of token data from headers to Set-Cookie field.