### PR TITLE
Rancher 1037 Register UI module in okapi in ui-bundle-deploy job

### DIFF
--- a/pipelines/deprecated/project_deprecated.groovy
+++ b/pipelines/deprecated/project_deprecated.groovy
@@ -223,7 +223,7 @@ ansiColor('xterm') {
 
                 stage("Health check") {
                     // Checking the health of the Okapi service.
-                    common.healthCheck("https://${project_config.getDomains().okapi}/_/version")
+                    common.healthCheck("https://${project_config.getDomains().okapi}/_/version", tenant)
                 }
 
                 stage("Enable backend modules") {

--- a/pipelines/deprecated/project_deprecated.groovy
+++ b/pipelines/deprecated/project_deprecated.groovy
@@ -223,7 +223,7 @@ ansiColor('xterm') {
 
                 stage("Health check") {
                     // Checking the health of the Okapi service.
-                    common.healthCheck("https://${project_config.getDomains().okapi}/_/version", tenant)
+                    common.healthCheck("https://${project_config.getDomains().okapi}/_/version")
                 }
 
                 stage("Enable backend modules") {

--- a/pipelines/folioRancher/folioDevOpsTools/utilities/jira-tickers-move.groovy
+++ b/pipelines/folioRancher/folioDevOpsTools/utilities/jira-tickers-move.groovy
@@ -14,11 +14,10 @@ LinkedHashMap bugfest_map = [:]
 JiraClient jiraClient = getJiraClient(jira_host_link, jira_credentialsId)
 LinkedHashMap host_map = ["Nolana"       :"https://okapi-bugfest-nolana.int.aws.folio.org",
                           "Orchid"       :"https://okapi-bugfest-orchid.int.aws.folio.org",
-                          "Poppy"        :"https://okapi-bugfest-poppy.int.aws.folio.org",
                           "Pre-Orchid"   :"https://okapi-pre-bugfest-orchid.int.aws.folio.org",
                           "Morning-Glory":"https://okapi-bugfest-mg.int.aws.folio.org"
                     ] as LinkedHashMap
-ArrayList<String> Bugfest_envs = ["Orchid", "Nolana", "Pre-Orchid", "Poppy","Morning-Glory"]
+ArrayList<String> Bugfest_envs = ["Orchid", "Nolana", "Pre-Orchid", "Morning-Glory"]
 String tenant="fs09000000"
 
 properties([

--- a/pipelines/folioRancher/folioDevTools/moduleDeployment/custom-backend-module.groovy
+++ b/pipelines/folioRancher/folioDevTools/moduleDeployment/custom-backend-module.groovy
@@ -151,7 +151,7 @@ ansiColor('xterm') {
 
                 stage("Health check") {
                     // Checking the health of the Okapi service.
-                    common.healthCheck("https://${project_config.getDomains().okapi}/_/version")
+                    common.healthCheck("https://${project_config.getDomains().okapi}/_/version", tenant)
                 }
 
                 stage("Enable backend modules") {

--- a/pipelines/folioRancher/folioDevTools/moduleDeployment/custom-backend-module.groovy
+++ b/pipelines/folioRancher/folioDevTools/moduleDeployment/custom-backend-module.groovy
@@ -151,7 +151,7 @@ ansiColor('xterm') {
 
                 stage("Health check") {
                     // Checking the health of the Okapi service.
-                    common.healthCheck("https://${project_config.getDomains().okapi}/_/version", tenant)
+                    common.healthCheck("https://${project_config.getDomains().okapi}/_/version")
                 }
 
                 stage("Enable backend modules") {

--- a/pipelines/folioRancher/folioDevTools/moduleDeployment/update-backend-modules-branch.groovy
+++ b/pipelines/folioRancher/folioDevTools/moduleDeployment/update-backend-modules-branch.groovy
@@ -140,7 +140,7 @@ ansiColor('xterm') {
 
             stage("Health check") {
                 // Checking the health of the Okapi service.
-                common.healthCheck("https://${project_config.getDomains().okapi}/_/version")
+                common.healthCheck("https://${project_config.getDomains().okapi}/_/version", tenant)
             }
 
             stage("Enable backend modules") {

--- a/pipelines/folioRancher/folioDevTools/moduleDeployment/update-backend-modules-branch.groovy
+++ b/pipelines/folioRancher/folioDevTools/moduleDeployment/update-backend-modules-branch.groovy
@@ -140,7 +140,7 @@ ansiColor('xterm') {
 
             stage("Health check") {
                 // Checking the health of the Okapi service.
-                common.healthCheck("https://${project_config.getDomains().okapi}/_/version", tenant)
+                common.healthCheck("https://${project_config.getDomains().okapi}/_/version")
             }
 
             stage("Enable backend modules") {

--- a/pipelines/folioRancher/folioDevTools/moduleDeployment/update-backend-modules.groovy
+++ b/pipelines/folioRancher/folioDevTools/moduleDeployment/update-backend-modules.groovy
@@ -110,7 +110,7 @@ ansiColor('xterm') {
 
             stage("Health check") {
                 // Checking the health of the Okapi service.
-                common.healthCheck("https://${project_config.getDomains().okapi}/_/version")
+                common.healthCheck("https://${project_config.getDomains().okapi}/_/version", tenant)
             }
 
             stage("Enable backend modules") {

--- a/pipelines/folioRancher/folioDevTools/moduleDeployment/update-backend-modules.groovy
+++ b/pipelines/folioRancher/folioDevTools/moduleDeployment/update-backend-modules.groovy
@@ -110,7 +110,7 @@ ansiColor('xterm') {
 
             stage("Health check") {
                 // Checking the health of the Okapi service.
-                common.healthCheck("https://${project_config.getDomains().okapi}/_/version", tenant)
+                common.healthCheck("https://${project_config.getDomains().okapi}/_/version")
             }
 
             stage("Enable backend modules") {

--- a/pipelines/folioRancher/folioDevTools/uiManagement/buildUI/Jenkinsfile
+++ b/pipelines/folioRancher/folioDevTools/uiManagement/buildUI/Jenkinsfile
@@ -10,7 +10,7 @@ import org.folio.models.TenantUi
 import org.folio.rest.GitHubUtility
 import org.jenkinsci.plugins.workflow.libs.Library
 
-@Library('pipelines-shared-library@RANCHER-835') _
+@Library('pipelines-shared-library@RANCHER-835-v2') _
 
 properties([
     buildDiscarder(logRotator(numToKeepStr: '30')),

--- a/pipelines/folioRancher/folioDevTools/uiManagement/buildUI/Jenkinsfile
+++ b/pipelines/folioRancher/folioDevTools/uiManagement/buildUI/Jenkinsfile
@@ -71,18 +71,12 @@ ansiColor('xterm') {
     try {
       stage('Ini') {
         buildName "${params.CLUSTER}-${params.NAMESPACE}.${env.BUILD_ID}"
-        buildDescription "For build UI bundle"
+        buildDescription "For build UI bundle\nBranch: ${params.FOLIO_BRANCH}\nConsortia: ${params.CONSORTIA}"
       }
       stage('Checkout') {
         checkout scm
       }
       stage('Build UI') {
-//        namespace.getTenants().each { tenantId, tenant ->
-//          if (tenant.getTenantUi()) {
-//            TenantUi ui = tenant.getTenantUi()
-//            println(ui)
-//            println(tenant)
-//          }}
         TenantUi ui = namespace.getTenants()[params.TENANT_ID].getTenantUi()
         OkapiTenant uiConsortia = namespace.getTenants()[params.TENANT_ID]
         def jobParameters = [

--- a/pipelines/folioRancher/folioDevTools/uiManagement/buildUI/Jenkinsfile
+++ b/pipelines/folioRancher/folioDevTools/uiManagement/buildUI/Jenkinsfile
@@ -80,7 +80,7 @@ ansiColor('xterm') {
         TenantUi ui = namespace.getTenants()[params.TENANT_ID].getTenantUi()
 //        OkapiTenant uiConsortia = namespace.getTenants()[params.TENANT_ID]
         def jobParameters = [
-          OKAPI_URL: namespace.getDomains()['okapi'],
+          OKAPI_URL: "https://${namespace.getDomains()['okapi']}",
           TENANT_ID  : ui.getTenantId(),
           CUSTOM_HASH: ui.getHash(),
           IMAGE_NAME: ui.getImageName(),

--- a/pipelines/folioRancher/folioDevTools/uiManagement/buildUI/Jenkinsfile
+++ b/pipelines/folioRancher/folioDevTools/uiManagement/buildUI/Jenkinsfile
@@ -10,7 +10,7 @@ import org.folio.models.TenantUi
 import org.folio.rest.GitHubUtility
 import org.jenkinsci.plugins.workflow.libs.Library
 
-@Library('pipelines-shared-library@RANCHER-835-v2') _
+@Library('pipelines-shared-library@RANCHER-835') _
 
 properties([
     buildDiscarder(logRotator(numToKeepStr: '30')),

--- a/pipelines/folioRancher/folioDevTools/uiManagement/buildUI/Jenkinsfile
+++ b/pipelines/folioRancher/folioDevTools/uiManagement/buildUI/Jenkinsfile
@@ -78,7 +78,6 @@ ansiColor('xterm') {
       }
       stage('Build UI') {
         TenantUi ui = namespace.getTenants()[params.TENANT_ID].getTenantUi()
-//        OkapiTenant uiConsortia = namespace.getTenants()[params.TENANT_ID]
         def jobParameters = [
           OKAPI_URL: "https://${namespace.getDomains()['okapi']}",
           TENANT_ID  : ui.getTenantId(),

--- a/pipelines/folioRancher/folioDevTools/uiManagement/buildUI/Jenkinsfile
+++ b/pipelines/folioRancher/folioDevTools/uiManagement/buildUI/Jenkinsfile
@@ -3,14 +3,12 @@
 import org.folio.Constants
 import org.folio.models.Index
 import org.folio.models.InstallRequestParams
-import org.folio.models.OkapiTenant
-import org.folio.models.OkapiTenantConsortia
 import org.folio.models.RancherNamespace
 import org.folio.models.TenantUi
 import org.folio.rest.GitHubUtility
 import org.jenkinsci.plugins.workflow.libs.Library
 
-@Library('pipelines-shared-library@RANCHER-835') _
+@Library('pipelines-shared-library@RANCHER-741-Jenkins-Enhancements') _
 
 properties([
     buildDiscarder(logRotator(numToKeepStr: '30')),

--- a/pipelines/folioRancher/folioDevTools/uiManagement/buildUI/Jenkinsfile
+++ b/pipelines/folioRancher/folioDevTools/uiManagement/buildUI/Jenkinsfile
@@ -78,13 +78,13 @@ ansiColor('xterm') {
       }
       stage('Build UI') {
         TenantUi ui = namespace.getTenants()[params.TENANT_ID].getTenantUi()
-        OkapiTenant uiConsortia = namespace.getTenants()[params.TENANT_ID]
+//        OkapiTenant uiConsortia = namespace.getTenants()[params.TENANT_ID]
         def jobParameters = [
           OKAPI_URL: namespace.getDomains()['okapi'],
           TENANT_ID  : ui.getTenantId(),
           CUSTOM_HASH: ui.getHash(),
           IMAGE_NAME: ui.getImageName(),
-          CONSORTIA  : uiConsortia instanceof OkapiTenantConsortia
+          CONSORTIA  : params.CONSORTIA
         ]
         folioUI.build(jobParameters)
       }

--- a/pipelines/folioRancher/folioDevTools/uiManagement/deployUI/Jenkinsfile
+++ b/pipelines/folioRancher/folioDevTools/uiManagement/deployUI/Jenkinsfile
@@ -95,7 +95,7 @@ ansiColor('xterm') {
         stage('UI Deploy') {
           TenantUi ui = namespace.getTenants()[params.TENANT_ID].getTenantUi()
           folioHelm.withKubeConfig(namespace.getClusterName()) {
-            folioHelm.deployFolioModule(namespace, 'ui-bundle', ui.getTag(), false, ui.getTenantId())
+            folioHelm.deployFolioModule(params.NAMESPACE, 'ui-bundle', ui.getTag(), false, ui.getTenantId())
           }
 
         }

--- a/pipelines/folioRancher/folioDevTools/uiManagement/deployUI/Jenkinsfile
+++ b/pipelines/folioRancher/folioDevTools/uiManagement/deployUI/Jenkinsfile
@@ -44,13 +44,10 @@ RancherNamespace namespace = new RancherNamespace(params.CLUSTER, params.NAMESPA
   .withSuperTenantAdminUser()
   .withOkapiVersion(params.OKAPI_VERSION)
   .withDefaultTenant(defaultTenantId)
-  .withDeploymentConfigType(params.CONFIG_TYPE)
+//  .withDeploymentConfigType(params.CONFIG_TYPE)
 
 namespace.getModules().setInstallJson(installJson)
 namespace.addDeploymentConfig(CONFIG_BRANCH)
-
-println(namespace.addDeploymentConfig(CONFIG_BRANCH))
-println(namespace.withDeploymentConfigType(CONFIG_TYPE))
 
 namespace.addTenant(folioDefault.tenants()[namespace.getDefaultTenantId()]
   .withInstallJson(namespace.getModules().getInstallJson().collect())

--- a/pipelines/folioRancher/folioDevTools/uiManagement/deployUI/Jenkinsfile
+++ b/pipelines/folioRancher/folioDevTools/uiManagement/deployUI/Jenkinsfile
@@ -58,7 +58,6 @@ namespace.addTenant(folioDefault.tenants()[namespace.getDefaultTenantId()]
   .withTenantUi(tenantUi.clone())
 )
 
-//OkapiTenant OkapiTenant = new OkapiTenant()
 Okapi okapi = new Okapi(this, namespace.getDomains()['okapi'], namespace.getSuperTenant())
 
 if (params.CONSORTIA) {

--- a/pipelines/folioRancher/folioDevTools/uiManagement/deployUI/Jenkinsfile
+++ b/pipelines/folioRancher/folioDevTools/uiManagement/deployUI/Jenkinsfile
@@ -95,11 +95,11 @@ ansiColor('xterm') {
         stage('UI Deploy') {
           TenantUi ui = namespace.getTenants()[params.TENANT_ID].getTenantUi()
           OkapiTenant uiConsortia = namespace.getTenants()[params.TENANT_ID]
-          println(uiConsortia)
-          println(namespace)
-          println(ui)
-          println(ui.getTag())
-          println(ui.getTenantId())
+//          println(uiConsortia)
+//          println(namespace)
+//          println(ui)
+//          println(ui.getTag())
+//          println(ui.getTenantId())
           folioHelm.withKubeConfig(namespace.getClusterName()) {
             folioHelm.deployFolioModule(namespace, 'ui-bundle', ui.getTag(), false, ui.getTenantId())
           }

--- a/pipelines/folioRancher/folioDevTools/uiManagement/deployUI/Jenkinsfile
+++ b/pipelines/folioRancher/folioDevTools/uiManagement/deployUI/Jenkinsfile
@@ -9,9 +9,9 @@ import org.folio.models.TenantUi
 import org.folio.rest_v2.Okapi
 import org.jenkinsci.plugins.workflow.libs.Library
 
-@Library('pipelines-shared-library@RANCHER-741-Jenkins-Enhancements') _
+@Library('pipelines-shared-library@RANCHER-1037-v2') _
 
-CONFIG_BRANCH = 'RANCHER-741-Jenkins-Enhancements'
+CONFIG_BRANCH = 'RANCHER-1037-v2'
 
 properties([
     buildDiscarder(logRotator(numToKeepStr: '30')),

--- a/pipelines/folioRancher/folioDevTools/uiManagement/deployUI/Jenkinsfile
+++ b/pipelines/folioRancher/folioDevTools/uiManagement/deployUI/Jenkinsfile
@@ -46,9 +46,11 @@ RancherNamespace namespace = new RancherNamespace(params.CLUSTER, params.NAMESPA
   .withDefaultTenant(defaultTenantId)
   .withDeploymentConfigType(params.CONFIG_TYPE)
 
-//namespace.setEnableRwSplit()
 namespace.getModules().setInstallJson(installJson)
 namespace.addDeploymentConfig(CONFIG_BRANCH)
+
+println(namespace.addDeploymentConfig(CONFIG_BRANCH))
+println(namespace.withDeploymentConfigType(CONFIG_TYPE))
 
 namespace.addTenant(folioDefault.tenants()[namespace.getDefaultTenantId()]
   .withInstallJson(namespace.getModules().getInstallJson().collect())

--- a/pipelines/folioRancher/folioDevTools/uiManagement/deployUI/Jenkinsfile
+++ b/pipelines/folioRancher/folioDevTools/uiManagement/deployUI/Jenkinsfile
@@ -3,16 +3,14 @@
 import org.folio.Constants
 import org.folio.models.Index
 import org.folio.models.InstallRequestParams
-import org.folio.models.OkapiTenant
-import org.folio.models.OkapiTenantConsortia
 import org.folio.models.RancherNamespace
 import org.folio.rest.GitHubUtility
 import org.folio.models.TenantUi
 import org.jenkinsci.plugins.workflow.libs.Library
 
-@Library('pipelines-shared-library@RANCHER-835') _
+@Library('pipelines-shared-library@RANCHER-741-Jenkins-Enhancements') _
 
-CONFIG_BRANCH = 'RANCHER-835'
+CONFIG_BRANCH = 'RANCHER-741-Jenkins-Enhancements'
 
 properties([
     buildDiscarder(logRotator(numToKeepStr: '30')),

--- a/pipelines/folioRancher/folioDevTools/uiManagement/deployUI/Jenkinsfile
+++ b/pipelines/folioRancher/folioDevTools/uiManagement/deployUI/Jenkinsfile
@@ -1,12 +1,13 @@
 #!groovy
 
-import org.folio.Constants
+//import org.folio.Constants
 import org.folio.models.Index
 import org.folio.models.InstallRequestParams
 import org.folio.models.RancherNamespace
 import org.folio.rest.GitHubUtility
 import org.folio.models.TenantUi
 import org.folio.rest_v2.Okapi
+//import org.folio.models.OkapiTenant
 import org.jenkinsci.plugins.workflow.libs.Library
 
 @Library('pipelines-shared-library@RANCHER-1037-v2') _
@@ -56,6 +57,7 @@ namespace.addTenant(folioDefault.tenants()[namespace.getDefaultTenantId()]
   .withTenantUi(tenantUi.clone())
 )
 
+//OkapiTenant OkapiTenant = new OkapiTenant()
 Okapi okapi = new Okapi(this, namespace.getDomains()['okapi'], namespace.getSuperTenant())
 
 if (params.CONSORTIA) {
@@ -82,9 +84,6 @@ ansiColor('xterm') {
         stage('Checkout') {
           checkout scm
         }
-        stage('updateTenantModules')  {
-          okapi.tenantInstall(namespace.getTenants()[params.TENANT_ID].getTenantUi(), namespace.getModules().getInstallJson())
-        }
         if (params.UI_BUNDLE_BUILD) {
           stage('UI Build') {
             TenantUi ui = namespace.getTenants()[params.TENANT_ID].getTenantUi()
@@ -104,6 +103,9 @@ ansiColor('xterm') {
           folioHelm.withKubeConfig(namespace.getClusterName()) {
             folioHelm.deployFolioModule(namespace, 'ui-bundle', ui.getTag(), false, ui.getTenantId())
           }
+        }
+        stage('updateTenantModules')  {
+          okapi.tenantInstall(namespace.getSuperTenant(), namespace.getModules().getInstallJson())
         }
     } catch (e) {
         println "Caught exception: ${e}"

--- a/pipelines/folioRancher/folioDevTools/uiManagement/deployUI/Jenkinsfile
+++ b/pipelines/folioRancher/folioDevTools/uiManagement/deployUI/Jenkinsfile
@@ -38,11 +38,11 @@ TenantUi tenantUi = new TenantUi("${params.CLUSTER}-${params.NAMESPACE}", commit
 InstallRequestParams installRequestParams = new InstallRequestParams()
   .withTenantParameters("loadReference=${params.LOAD_REFERENCE},loadSample=${params.LOAD_SAMPLE}")
 
-RancherNamespace namespace = new RancherNamespace("${params.CLUSTER}", "${params.NAMESPACE}")
+RancherNamespace namespace = new RancherNamespace(params.CLUSTER, params.NAMESPACE)
   .withSuperTenantAdminUser()
-  .withOkapiVersion("${params.OKAPI_VERSION}")
-  .withDefaultTenant("${defaultTenantId}")
-  .withDeploymentConfigType("${params.CONFIG_TYPE}")
+  .withOkapiVersion(params.OKAPI_VERSION)
+  .withDefaultTenant(defaultTenantId)
+  .withDeploymentConfigType(params.CONFIG_TYPE)
 
 namespace.getModules().setInstallJson(installJson)
 

--- a/pipelines/folioRancher/folioDevTools/uiManagement/deployUI/Jenkinsfile
+++ b/pipelines/folioRancher/folioDevTools/uiManagement/deployUI/Jenkinsfile
@@ -94,12 +94,6 @@ ansiColor('xterm') {
 
         stage('UI Deploy') {
           TenantUi ui = namespace.getTenants()[params.TENANT_ID].getTenantUi()
-//          def parameters = [
-//            CLUSTER      : namespace.getClusterName(),
-//            NAMESPACE    : namespace.getNamespaceName(),
-//            UI_BUNDLE_TAG: params.UI_BUNDLE_BUILD ? ui.getTag() : params.UI_BUNDLE_TAG,
-//            TENANT_ID    : ui.getTenantId()
-//          ]
           folioHelm.withKubeConfig(namespace.getClusterName()) {
             folioHelm.deployFolioModule(namespace, 'ui-bundle', ui.getTag(), false, ui.getTenantId())
           }

--- a/pipelines/folioRancher/folioDevTools/uiManagement/deployUI/Jenkinsfile
+++ b/pipelines/folioRancher/folioDevTools/uiManagement/deployUI/Jenkinsfile
@@ -57,8 +57,6 @@ namespace.addTenant(folioDefault.tenants()[namespace.getDefaultTenantId()]
 
 Main main = new Main(this, namespace.getDomains()['okapi'], namespace.getSuperTenant())
 List UIModuleList = installJson.findAll { it.id?.startsWith('folio_') == true }
-println UIModuleList
-
 
 if (params.CONSORTIA) {
   namespace.setEnableConsortia(true)
@@ -104,10 +102,9 @@ ansiColor('xterm') {
             folioHelm.deployFolioModule(namespace, 'ui-bundle', ui.getTag(), false, ui.getTenantId())
           }
         }
-        input "test"
-        stage('updateUIModules')  {
+        stage('Update UI Modules')  {
           main.preInstallUI(UIModuleList)
-          main.update(defaultTenantId)
+          main.update(namespace.getTenants())
         }
     } catch (e) {
         println "Caught exception: ${e}"

--- a/pipelines/folioRancher/folioDevTools/uiManagement/deployUI/Jenkinsfile
+++ b/pipelines/folioRancher/folioDevTools/uiManagement/deployUI/Jenkinsfile
@@ -100,8 +100,8 @@ ansiColor('xterm') {
             UI_BUNDLE_TAG: params.UI_BUNDLE_BUILD ? ui.getTag() : params.UI_BUNDLE_TAG,
             TENANT_ID    : ui.getTenantId()
           ]
-          folioHelm.withKubeConfig(namespace.getClusterName()) {
-            folioHelm.deployFolioModule(namespace, 'ui-bundle', parameters.UI_BUNDLE_TAG, false, parameters.TENANT_ID)
+          folioHelm.withKubeConfig(parameters.CLUSTER) {
+            folioHelm.deployFolioModule(namespace.getClusterName() as RancherNamespace, 'ui-bundle', parameters.UI_BUNDLE_TAG, false, parameters.TENANT_ID)
           }
 
         }

--- a/pipelines/folioRancher/folioDevTools/uiManagement/deployUI/Jenkinsfile
+++ b/pipelines/folioRancher/folioDevTools/uiManagement/deployUI/Jenkinsfile
@@ -1,13 +1,11 @@
 #!groovy
 
-//import org.folio.Constants
 import org.folio.models.Index
 import org.folio.models.InstallRequestParams
 import org.folio.models.RancherNamespace
 import org.folio.rest.GitHubUtility
 import org.folio.models.TenantUi
-import org.folio.rest_v2.Okapi
-//import org.folio.models.OkapiTenant
+import org.folio.rest_v2.Main
 import org.jenkinsci.plugins.workflow.libs.Library
 
 @Library('pipelines-shared-library@RANCHER-1037-v2') _
@@ -37,7 +35,6 @@ String defaultTenantId = 'diku'
 //Set namespace configuration
 String commitHash = params.CUSTOM_HASH?.trim() ? params.CUSTOM_HASH : common.getLastCommitHash(params.FOLIO_REPOSITORY, params.FOLIO_BRANCH)
 List installJson = new GitHubUtility(this).getEnableList('platform-complete', params.FOLIO_BRANCH)
-println installJson
 TenantUi tenantUi = new TenantUi("${params.CLUSTER}-${params.NAMESPACE}", commitHash, params.FOLIO_BRANCH)
 InstallRequestParams installRequestParams = new InstallRequestParams()
   .withTenantParameters("loadReference=${params.LOAD_REFERENCE},loadSample=${params.LOAD_SAMPLE}")
@@ -58,7 +55,10 @@ namespace.addTenant(folioDefault.tenants()[namespace.getDefaultTenantId()]
   .withTenantUi(tenantUi.clone())
 )
 
-Okapi okapi = new Okapi(this, namespace.getDomains()['okapi'], namespace.getSuperTenant())
+Main main = new Main(this, namespace.getDomains()['okapi'], namespace.getSuperTenant())
+List UIModuleList = installJson.findAll { it.id?.startsWith('folio_') == true }
+println UIModuleList
+
 
 if (params.CONSORTIA) {
   namespace.setEnableConsortia(true)
@@ -106,7 +106,8 @@ ansiColor('xterm') {
         }
         input "test"
         stage('updateUIModules')  {
-          okapi.tenantInstall(namespace.getSuperTenant(), installJson)
+          main.preInstallUI(UIModules)
+          main.update(defaultTenantId)
         }
     } catch (e) {
         println "Caught exception: ${e}"

--- a/pipelines/folioRancher/folioDevTools/uiManagement/deployUI/Jenkinsfile
+++ b/pipelines/folioRancher/folioDevTools/uiManagement/deployUI/Jenkinsfile
@@ -94,6 +94,8 @@ ansiColor('xterm') {
 
         stage('UI Deploy') {
           TenantUi ui = namespace.getTenants()[params.TENANT_ID].getTenantUi()
+          OkapiTenant uiConsortia = namespace.getTenants()[params.TENANT_ID]
+          println(uiConsortia)
           println(namespace)
           println(ui)
           println(ui.getTag())

--- a/pipelines/folioRancher/folioDevTools/uiManagement/deployUI/Jenkinsfile
+++ b/pipelines/folioRancher/folioDevTools/uiManagement/deployUI/Jenkinsfile
@@ -94,10 +94,13 @@ ansiColor('xterm') {
 
         stage('UI Deploy') {
           TenantUi ui = namespace.getTenants()[params.TENANT_ID].getTenantUi()
+          println(namespace)
+          println(ui)
+          println(ui.getTag())
+          println(ui.getTenantId())
           folioHelm.withKubeConfig(namespace.getClusterName()) {
             folioHelm.deployFolioModule(namespace, 'ui-bundle', ui.getTag(), false, ui.getTenantId())
           }
-
         }
     } catch (e) {
         println "Caught exception: ${e}"

--- a/pipelines/folioRancher/folioDevTools/uiManagement/deployUI/Jenkinsfile
+++ b/pipelines/folioRancher/folioDevTools/uiManagement/deployUI/Jenkinsfile
@@ -104,6 +104,7 @@ ansiColor('xterm') {
             folioHelm.deployFolioModule(namespace, 'ui-bundle', ui.getTag(), false, ui.getTenantId())
           }
         }
+        input "test"
         stage('updateUIModules')  {
           okapi.tenantInstall(namespace.getSuperTenant(), namespace.getModules().getInstallJson(installJson))
         }

--- a/pipelines/folioRancher/folioDevTools/uiManagement/deployUI/Jenkinsfile
+++ b/pipelines/folioRancher/folioDevTools/uiManagement/deployUI/Jenkinsfile
@@ -37,6 +37,7 @@ String defaultTenantId = 'diku'
 //Set namespace configuration
 String commitHash = params.CUSTOM_HASH?.trim() ? params.CUSTOM_HASH : common.getLastCommitHash(params.FOLIO_REPOSITORY, params.FOLIO_BRANCH)
 List installJson = new GitHubUtility(this).getEnableList('platform-complete', params.FOLIO_BRANCH)
+println installJson
 TenantUi tenantUi = new TenantUi("${params.CLUSTER}-${params.NAMESPACE}", commitHash, params.FOLIO_BRANCH)
 InstallRequestParams installRequestParams = new InstallRequestParams()
   .withTenantParameters("loadReference=${params.LOAD_REFERENCE},loadSample=${params.LOAD_SAMPLE}")
@@ -106,7 +107,7 @@ ansiColor('xterm') {
         }
         input "test"
         stage('updateUIModules')  {
-          okapi.tenantInstall(namespace.getSuperTenant(), namespace.getModules().getInstallJson(installJson))
+          okapi.tenantInstall(namespace.getSuperTenant(), installJson)
         }
     } catch (e) {
         println "Caught exception: ${e}"

--- a/pipelines/folioRancher/folioDevTools/uiManagement/deployUI/Jenkinsfile
+++ b/pipelines/folioRancher/folioDevTools/uiManagement/deployUI/Jenkinsfile
@@ -8,9 +8,9 @@ import org.folio.models.TenantUi
 import org.folio.rest_v2.Main
 import org.jenkinsci.plugins.workflow.libs.Library
 
-@Library('pipelines-shared-library@RANCHER-1037-v2') _
+@Library('pipelines-shared-library@RANCHER-741-Jenkins-Enhancements') _
 
-CONFIG_BRANCH = 'RANCHER-1037-v2'
+CONFIG_BRANCH = 'RANCHER-741-Jenkins-Enhancements'
 
 properties([
     buildDiscarder(logRotator(numToKeepStr: '30')),

--- a/pipelines/folioRancher/folioDevTools/uiManagement/deployUI/Jenkinsfile
+++ b/pipelines/folioRancher/folioDevTools/uiManagement/deployUI/Jenkinsfile
@@ -8,7 +8,6 @@ import org.folio.models.OkapiTenantConsortia
 import org.folio.models.RancherNamespace
 import org.folio.rest.GitHubUtility
 import org.folio.models.TenantUi
-import org.folio.rest_v2.Main
 import org.jenkinsci.plugins.workflow.libs.Library
 
 @Library('pipelines-shared-library@RANCHER-835-v2') _
@@ -99,7 +98,6 @@ ansiColor('xterm') {
             CLUSTER      : namespace.getClusterName(),
             NAMESPACE    : namespace.getNamespaceName(),
             UI_BUNDLE_TAG: params.UI_BUNDLE_BUILD ? ui.getTag() : params.UI_BUNDLE_TAG,
-//            GET_DOMAINS  : namespace.getDomains()['okapi'],
             TENANT_ID    : ui.getTenantId()
           ]
           folioHelm.withKubeConfig(parameters.CLUSTER) {

--- a/pipelines/folioRancher/folioDevTools/uiManagement/deployUI/Jenkinsfile
+++ b/pipelines/folioRancher/folioDevTools/uiManagement/deployUI/Jenkinsfile
@@ -100,8 +100,8 @@ ansiColor('xterm') {
             UI_BUNDLE_TAG: params.UI_BUNDLE_BUILD ? ui.getTag() : params.UI_BUNDLE_TAG,
             TENANT_ID    : ui.getTenantId()
           ]
-          folioHelm.withKubeConfig(parameters.CLUSTER) {
-            folioHelm.deployFolioModule(parameters.NAMESPACE, 'ui-bundle', parameters.UI_BUNDLE_TAG, false, parameters.TENANT_ID)
+          folioHelm.withKubeConfig(namespace.getClusterName()) {
+            folioHelm.deployFolioModule(namespace, 'ui-bundle', parameters.UI_BUNDLE_TAG, false, parameters.TENANT_ID)
           }
 
         }

--- a/pipelines/folioRancher/folioDevTools/uiManagement/deployUI/Jenkinsfile
+++ b/pipelines/folioRancher/folioDevTools/uiManagement/deployUI/Jenkinsfile
@@ -46,6 +46,7 @@ RancherNamespace namespace = new RancherNamespace(params.CLUSTER, params.NAMESPA
   .withDefaultTenant(defaultTenantId)
   .withDeploymentConfigType(params.CONFIG_TYPE)
 
+namespace.setEnableRwSplit()
 namespace.getModules().setInstallJson(installJson)
 namespace.addDeploymentConfig(CONFIG_BRANCH)
 
@@ -97,7 +98,6 @@ ansiColor('xterm') {
 
         stage('UI Deploy') {
           TenantUi ui = namespace.getTenants()[params.TENANT_ID].getTenantUi()
-//          OkapiTenant uiConsortia = namespace.getTenants()[params.TENANT_ID]
           folioHelm.withKubeConfig(namespace.getClusterName()) {
             folioHelm.deployFolioModule(namespace, 'ui-bundle', ui.getTag(), false, ui.getTenantId())
           }

--- a/pipelines/folioRancher/folioDevTools/uiManagement/deployUI/Jenkinsfile
+++ b/pipelines/folioRancher/folioDevTools/uiManagement/deployUI/Jenkinsfile
@@ -10,9 +10,9 @@ import org.folio.rest.GitHubUtility
 import org.folio.models.TenantUi
 import org.jenkinsci.plugins.workflow.libs.Library
 
-@Library('pipelines-shared-library@RANCHER-835-v2') _
+@Library('pipelines-shared-library@RANCHER-835') _
 
-CONFIG_BRANCH = 'RANCHER-835-v2'
+CONFIG_BRANCH = 'RANCHER-835'
 
 properties([
     buildDiscarder(logRotator(numToKeepStr: '30')),

--- a/pipelines/folioRancher/folioDevTools/uiManagement/deployUI/Jenkinsfile
+++ b/pipelines/folioRancher/folioDevTools/uiManagement/deployUI/Jenkinsfile
@@ -89,21 +89,24 @@ ansiColor('xterm') {
               CONSORTIA  : uiConsortia instanceof OkapiTenantConsortia
             ]
             folioUI.build(jobParameters)
+            folioHelm.withKubeConfig(namespace.getClusterName()) {
+              folioHelm.deployFolioModule(namespace, 'ui-bundle', ui.getTag(), false, ui.getTenantId())
+              }
             }
           }
 
-        stage('UI Deploy') {
-          TenantUi ui = namespace.getTenants()[params.TENANT_ID].getTenantUi()
-          OkapiTenant uiConsortia = namespace.getTenants()[params.TENANT_ID]
-          println(uiConsortia)
-          println(namespace)
-          println(ui)
-          println(ui.getTag())
-          println(ui.getTenantId())
-          folioHelm.withKubeConfig(namespace.getClusterName()) {
-            folioHelm.deployFolioModule(namespace, 'ui-bundle', ui.getTag(), false, ui.getTenantId())
-          }
-        }
+//        stage('UI Deploy') {
+//          TenantUi ui = namespace.getTenants()[params.TENANT_ID].getTenantUi()
+//          OkapiTenant uiConsortia = namespace.getTenants()[params.TENANT_ID]
+//          println(uiConsortia)
+//          println(namespace)
+//          println(ui)
+//          println(ui.getTag())
+//          println(ui.getTenantId())
+//          folioHelm.withKubeConfig(namespace.getClusterName()) {
+//            folioHelm.deployFolioModule(namespace, 'ui-bundle', ui.getTag(), false, ui.getTenantId())
+//          }
+//        }
     } catch (e) {
         println "Caught exception: ${e}"
         error(e.getMessage())

--- a/pipelines/folioRancher/folioDevTools/uiManagement/deployUI/Jenkinsfile
+++ b/pipelines/folioRancher/folioDevTools/uiManagement/deployUI/Jenkinsfile
@@ -95,15 +95,15 @@ ansiColor('xterm') {
 
         stage('UI Deploy') {
           TenantUi ui = namespace.getTenants()[params.TENANT_ID].getTenantUi()
-          def params = [
+          def parameters = [
             CLUSTER      : namespace.getClusterName(),
             NAMESPACE    : namespace.getNamespaceName(),
             UI_BUNDLE_TAG: params.UI_BUNDLE_BUILD ? ui.getTag() : params.UI_BUNDLE_TAG,
 //            GET_DOMAINS  : namespace.getDomains()['okapi'],
             TENANT_ID    : ui.getTenantId()
           ]
-          folioHelm.withKubeConfig(params.CLUSTER) {
-            folioHelm.deployFolioModule(params.NAMESPACE, 'ui-bundle', params.UI_BUNDLE_TAG, false, params.TENANT_ID)
+          folioHelm.withKubeConfig(parameters.CLUSTER) {
+            folioHelm.deployFolioModule(parameters.NAMESPACE, 'ui-bundle', parameters.UI_BUNDLE_TAG, false, parameters.TENANT_ID)
           }
 
         }

--- a/pipelines/folioRancher/folioDevTools/uiManagement/deployUI/Jenkinsfile
+++ b/pipelines/folioRancher/folioDevTools/uiManagement/deployUI/Jenkinsfile
@@ -93,7 +93,7 @@ ansiColor('xterm') {
           }
 
         stage('UI Deploy') {
-          TenantUi ui = namespace.getTenants()[params.TENANT_ID]
+          TenantUi ui = namespace.getTenants()[params.TENANT_ID].getTenantUi()
           OkapiTenant uiConsortia = namespace.getTenants()[params.TENANT_ID]
           println(uiConsortia)
           println(namespace)

--- a/pipelines/folioRancher/folioDevTools/uiManagement/deployUI/Jenkinsfile
+++ b/pipelines/folioRancher/folioDevTools/uiManagement/deployUI/Jenkinsfile
@@ -106,7 +106,7 @@ ansiColor('xterm') {
         }
         input "test"
         stage('updateUIModules')  {
-          main.preInstallUI(UIModules)
+          main.preInstallUI(UIModuleList)
           main.update(defaultTenantId)
         }
     } catch (e) {

--- a/pipelines/folioRancher/folioDevTools/uiManagement/deployUI/Jenkinsfile
+++ b/pipelines/folioRancher/folioDevTools/uiManagement/deployUI/Jenkinsfile
@@ -76,7 +76,7 @@ ansiColor('xterm') {
       try {
         stage('Ini') {
           buildName "${params.CLUSTER}-${params.NAMESPACE}.${env.BUILD_ID}"
-          buildDescription "For deploy UI bundle"
+          buildDescription "For deploy UI bundle\nBranch: ${params.FOLIO_BRANCH}\nConfig: ${params.CONFIG_TYPE} "
         }
         stage('Checkout') {
           checkout scm

--- a/pipelines/folioRancher/folioDevTools/uiManagement/deployUI/Jenkinsfile
+++ b/pipelines/folioRancher/folioDevTools/uiManagement/deployUI/Jenkinsfile
@@ -22,6 +22,7 @@ properties([
         folioParameters.namespace(),
         folioParameters.repository(),
         folioParameters.branch(),
+        folioParameters.configType(),
         folioParameters.tenantId(),
         folioParameters.uiBundleBuild(),
         folioParameters.uiBundleTag(),
@@ -44,7 +45,7 @@ RancherNamespace namespace = new RancherNamespace(params.CLUSTER, params.NAMESPA
   .withSuperTenantAdminUser()
   .withOkapiVersion(params.OKAPI_VERSION)
   .withDefaultTenant(defaultTenantId)
-//  .withDeploymentConfigType(params.CONFIG_TYPE)
+  .withDeploymentConfigType(params.CONFIG_TYPE)
 
 namespace.getModules().setInstallJson(installJson)
 namespace.addDeploymentConfig(CONFIG_BRANCH)

--- a/pipelines/folioRancher/folioDevTools/uiManagement/deployUI/Jenkinsfile
+++ b/pipelines/folioRancher/folioDevTools/uiManagement/deployUI/Jenkinsfile
@@ -94,14 +94,14 @@ ansiColor('xterm') {
 
         stage('UI Deploy') {
           TenantUi ui = namespace.getTenants()[params.TENANT_ID].getTenantUi()
-          def parameters = [
-            CLUSTER      : namespace.getClusterName(),
-            NAMESPACE    : namespace.getNamespaceName(),
-            UI_BUNDLE_TAG: params.UI_BUNDLE_BUILD ? ui.getTag() : params.UI_BUNDLE_TAG,
-            TENANT_ID    : ui.getTenantId()
-          ]
-          folioHelm.withKubeConfig(parameters.CLUSTER) {
-            folioHelm.deployFolioModule(namespace.getClusterName() as RancherNamespace, 'ui-bundle', parameters.UI_BUNDLE_TAG, false, parameters.TENANT_ID)
+//          def parameters = [
+//            CLUSTER      : namespace.getClusterName(),
+//            NAMESPACE    : namespace.getNamespaceName(),
+//            UI_BUNDLE_TAG: params.UI_BUNDLE_BUILD ? ui.getTag() : params.UI_BUNDLE_TAG,
+//            TENANT_ID    : ui.getTenantId()
+//          ]
+          folioHelm.withKubeConfig(namespace.getClusterName()) {
+            folioHelm.deployFolioModule(namespace, 'ui-bundle', ui.getTag(), false, ui.getTenantId())
           }
 
         }

--- a/pipelines/folioRancher/folioDevTools/uiManagement/deployUI/Jenkinsfile
+++ b/pipelines/folioRancher/folioDevTools/uiManagement/deployUI/Jenkinsfile
@@ -93,7 +93,7 @@ ansiColor('xterm') {
           }
 
         stage('UI Deploy') {
-          TenantUi ui = namespace.getTenants()[params.TENANT_ID].getTenantUi()
+          TenantUi ui = namespace.getTenants()[params.TENANT_ID]
           OkapiTenant uiConsortia = namespace.getTenants()[params.TENANT_ID]
           println(uiConsortia)
           println(namespace)

--- a/pipelines/folioRancher/folioDevTools/uiManagement/deployUI/Jenkinsfile
+++ b/pipelines/folioRancher/folioDevTools/uiManagement/deployUI/Jenkinsfile
@@ -94,14 +94,16 @@ ansiColor('xterm') {
 
         stage('UI Deploy') {
           TenantUi ui = namespace.getTenants()[params.TENANT_ID].getTenantUi()
-          def jobParameters = [
+          def params = [
             CLUSTER      : namespace.getClusterName(),
             NAMESPACE    : namespace.getNamespaceName(),
             UI_BUNDLE_TAG: params.UI_BUNDLE_BUILD ? ui.getTag() : params.UI_BUNDLE_TAG,
-            GET_DOMAINS  : namespace.getDomains()['okapi'],
+//            GET_DOMAINS  : namespace.getDomains()['okapi'],
             TENANT_ID    : ui.getTenantId()
           ]
-          folioUI.deploy(jobParameters)
+          folioHelm.withKubeConfig(params.CLUSTER) {
+            folioHelm.deployFolioModule(params.NAMESPACE, 'ui-bundle', params.UI_BUNDLE_TAG, false, params.TENANT_ID)
+          }
 
         }
     } catch (e) {

--- a/pipelines/folioRancher/folioDevTools/uiManagement/deployUI/Jenkinsfile
+++ b/pipelines/folioRancher/folioDevTools/uiManagement/deployUI/Jenkinsfile
@@ -12,6 +12,8 @@ import org.jenkinsci.plugins.workflow.libs.Library
 
 @Library('pipelines-shared-library@RANCHER-835-v2') _
 
+CONFIG_BRANCH = 'RANCHER-835-v2'
+
 properties([
     buildDiscarder(logRotator(numToKeepStr: '30')),
     disableConcurrentBuilds(),
@@ -45,6 +47,7 @@ RancherNamespace namespace = new RancherNamespace(params.CLUSTER, params.NAMESPA
   .withDeploymentConfigType(params.CONFIG_TYPE)
 
 namespace.getModules().setInstallJson(installJson)
+namespace.addDeploymentConfig(CONFIG_BRANCH)
 
 namespace.addTenant(folioDefault.tenants()[namespace.getDefaultTenantId()]
   .withInstallJson(namespace.getModules().getInstallJson().collect())

--- a/pipelines/folioRancher/folioDevTools/uiManagement/deployUI/Jenkinsfile
+++ b/pipelines/folioRancher/folioDevTools/uiManagement/deployUI/Jenkinsfile
@@ -104,8 +104,8 @@ ansiColor('xterm') {
             folioHelm.deployFolioModule(namespace, 'ui-bundle', ui.getTag(), false, ui.getTenantId())
           }
         }
-        stage('updateTenantModules')  {
-          okapi.tenantInstall(namespace.getSuperTenant(), namespace.getModules().getInstallJson())
+        stage('updateUIModules')  {
+          okapi.tenantInstall(namespace.getSuperTenant(), namespace.getModules().getInstallJson(installJson))
         }
     } catch (e) {
         println "Caught exception: ${e}"

--- a/pipelines/folioRancher/folioDevTools/uiManagement/deployUI/Jenkinsfile
+++ b/pipelines/folioRancher/folioDevTools/uiManagement/deployUI/Jenkinsfile
@@ -6,6 +6,7 @@ import org.folio.models.InstallRequestParams
 import org.folio.models.RancherNamespace
 import org.folio.rest.GitHubUtility
 import org.folio.models.TenantUi
+import org.folio.rest_v2.Okapi
 import org.jenkinsci.plugins.workflow.libs.Library
 
 @Library('pipelines-shared-library@RANCHER-741-Jenkins-Enhancements') _
@@ -31,6 +32,7 @@ properties([
     ])
 ])
 String defaultTenantId = 'diku'
+Okapi okapi = new Okapi(this, namespace.getDomains()['okapi'], namespace.getSuperTenant())
 
 //Set namespace configuration
 String commitHash = params.CUSTOM_HASH?.trim() ? params.CUSTOM_HASH : common.getLastCommitHash(params.FOLIO_REPOSITORY, params.FOLIO_BRANCH)
@@ -78,6 +80,9 @@ ansiColor('xterm') {
         }
         stage('Checkout') {
           checkout scm
+        }
+        stage('updateTenantModules')  {
+          okapi.tenantInstall(namespace.getTenants()[params.TENANT_ID].getTenantUi(), namespace.getModules().getInstallJson())
         }
         if (params.UI_BUNDLE_BUILD) {
           stage('UI Build') {

--- a/pipelines/folioRancher/folioDevTools/uiManagement/deployUI/Jenkinsfile
+++ b/pipelines/folioRancher/folioDevTools/uiManagement/deployUI/Jenkinsfile
@@ -32,7 +32,6 @@ properties([
     ])
 ])
 String defaultTenantId = 'diku'
-Okapi okapi = new Okapi(this, namespace.getDomains()['okapi'], namespace.getSuperTenant())
 
 //Set namespace configuration
 String commitHash = params.CUSTOM_HASH?.trim() ? params.CUSTOM_HASH : common.getLastCommitHash(params.FOLIO_REPOSITORY, params.FOLIO_BRANCH)
@@ -56,6 +55,8 @@ namespace.addTenant(folioDefault.tenants()[namespace.getDefaultTenantId()]
   .withInstallRequestParams(installRequestParams.clone())
   .withTenantUi(tenantUi.clone())
 )
+
+Okapi okapi = new Okapi(this, namespace.getDomains()['okapi'], namespace.getSuperTenant())
 
 if (params.CONSORTIA) {
   namespace.setEnableConsortia(true)

--- a/pipelines/folioRancher/folioDevTools/uiManagement/deployUI/Jenkinsfile
+++ b/pipelines/folioRancher/folioDevTools/uiManagement/deployUI/Jenkinsfile
@@ -46,7 +46,7 @@ RancherNamespace namespace = new RancherNamespace(params.CLUSTER, params.NAMESPA
   .withDefaultTenant(defaultTenantId)
   .withDeploymentConfigType(params.CONFIG_TYPE)
 
-namespace.setEnableRwSplit()
+//namespace.setEnableRwSplit()
 namespace.getModules().setInstallJson(installJson)
 namespace.addDeploymentConfig(CONFIG_BRANCH)
 

--- a/pipelines/folioRancher/folioDevTools/uiManagement/deployUI/Jenkinsfile
+++ b/pipelines/folioRancher/folioDevTools/uiManagement/deployUI/Jenkinsfile
@@ -89,24 +89,21 @@ ansiColor('xterm') {
               CONSORTIA  : uiConsortia instanceof OkapiTenantConsortia
             ]
             folioUI.build(jobParameters)
-            folioHelm.withKubeConfig(namespace.getClusterName()) {
-              folioHelm.deployFolioModule(namespace, 'ui-bundle', ui.getTag(), false, ui.getTenantId())
-              }
             }
           }
 
-//        stage('UI Deploy') {
-//          TenantUi ui = namespace.getTenants()[params.TENANT_ID].getTenantUi()
-//          OkapiTenant uiConsortia = namespace.getTenants()[params.TENANT_ID]
-//          println(uiConsortia)
-//          println(namespace)
-//          println(ui)
-//          println(ui.getTag())
-//          println(ui.getTenantId())
-//          folioHelm.withKubeConfig(namespace.getClusterName()) {
-//            folioHelm.deployFolioModule(namespace, 'ui-bundle', ui.getTag(), false, ui.getTenantId())
-//          }
-//        }
+        stage('UI Deploy') {
+          TenantUi ui = namespace.getTenants()[params.TENANT_ID].getTenantUi()
+          OkapiTenant uiConsortia = namespace.getTenants()[params.TENANT_ID]
+          println(uiConsortia)
+          println(namespace)
+          println(ui)
+          println(ui.getTag())
+          println(ui.getTenantId())
+          folioHelm.withKubeConfig(namespace.getClusterName()) {
+            folioHelm.deployFolioModule(namespace, 'ui-bundle', ui.getTag(), false, ui.getTenantId())
+          }
+        }
     } catch (e) {
         println "Caught exception: ${e}"
         error(e.getMessage())

--- a/pipelines/folioRancher/folioDevTools/uiManagement/deployUI/Jenkinsfile
+++ b/pipelines/folioRancher/folioDevTools/uiManagement/deployUI/Jenkinsfile
@@ -95,7 +95,7 @@ ansiColor('xterm') {
         stage('UI Deploy') {
           TenantUi ui = namespace.getTenants()[params.TENANT_ID].getTenantUi()
           folioHelm.withKubeConfig(namespace.getClusterName()) {
-            folioHelm.deployFolioModule(params.NAMESPACE, 'ui-bundle', ui.getTag(), false, ui.getTenantId())
+            folioHelm.deployFolioModule(namespace, 'ui-bundle', ui.getTag(), false, ui.getTenantId())
           }
 
         }

--- a/pipelines/folioRancher/folioDevTools/uiManagement/deployUI/Jenkinsfile
+++ b/pipelines/folioRancher/folioDevTools/uiManagement/deployUI/Jenkinsfile
@@ -84,7 +84,6 @@ ansiColor('xterm') {
         if (params.UI_BUNDLE_BUILD) {
           stage('UI Build') {
             TenantUi ui = namespace.getTenants()[params.TENANT_ID].getTenantUi()
-            OkapiTenant uiConsortia = namespace.getTenants()[params.TENANT_ID]
             def jobParameters = [
               OKAPI_URL  : "https://${namespace.getDomains()['okapi']}",
               TENANT_ID  : ui.getTenantId(),

--- a/pipelines/folioRancher/folioDevTools/uiManagement/deployUI/Jenkinsfile
+++ b/pipelines/folioRancher/folioDevTools/uiManagement/deployUI/Jenkinsfile
@@ -94,12 +94,7 @@ ansiColor('xterm') {
 
         stage('UI Deploy') {
           TenantUi ui = namespace.getTenants()[params.TENANT_ID].getTenantUi()
-          OkapiTenant uiConsortia = namespace.getTenants()[params.TENANT_ID]
-//          println(uiConsortia)
-//          println(namespace)
-//          println(ui)
-//          println(ui.getTag())
-//          println(ui.getTenantId())
+//          OkapiTenant uiConsortia = namespace.getTenants()[params.TENANT_ID]
           folioHelm.withKubeConfig(namespace.getClusterName()) {
             folioHelm.deployFolioModule(namespace, 'ui-bundle', ui.getTag(), false, ui.getTenantId())
           }

--- a/pipelines/folioRancher/folioDevTools/uiManagement/deployUI/Jenkinsfile
+++ b/pipelines/folioRancher/folioDevTools/uiManagement/deployUI/Jenkinsfile
@@ -86,11 +86,11 @@ ansiColor('xterm') {
             TenantUi ui = namespace.getTenants()[params.TENANT_ID].getTenantUi()
             OkapiTenant uiConsortia = namespace.getTenants()[params.TENANT_ID]
             def jobParameters = [
-              OKAPI_URL  : namespace.getDomains()['okapi'],
+              OKAPI_URL  : "https://${namespace.getDomains()['okapi']}",
               TENANT_ID  : ui.getTenantId(),
               CUSTOM_HASH: ui.getHash(),
               IMAGE_NAME : ui.getImageName(),
-              CONSORTIA  : uiConsortia instanceof OkapiTenantConsortia
+              CONSORTIA  : params.CONSORTIA
             ]
             folioUI.build(jobParameters)
             }

--- a/pipelines/folioRancher/folioDevTools/uiManagement/deployUI/Jenkinsfile
+++ b/pipelines/folioRancher/folioDevTools/uiManagement/deployUI/Jenkinsfile
@@ -8,6 +8,7 @@ import org.folio.models.OkapiTenantConsortia
 import org.folio.models.RancherNamespace
 import org.folio.rest.GitHubUtility
 import org.folio.models.TenantUi
+import org.folio.rest_v2.Main
 import org.jenkinsci.plugins.workflow.libs.Library
 
 @Library('pipelines-shared-library@RANCHER-835-v2') _

--- a/resources/helm/development.yaml
+++ b/resources/helm/development.yaml
@@ -727,16 +727,6 @@ mod-login-saml:
       memory: '341Mi'
     requests:
       memory: '256Mi'
-mod-marc-migrations:
-  javaOptions: '-XX:MaxRAMPercentage=85.0'
-  postJob:
-    enabled: false
-  replicaCount: 1
-  resources:
-    limits:
-      memory: '1024Mi'
-    requests:
-      memory: '768Mi'
 mod-ncip:
   javaOptions: '-XX:MaxRAMPercentage=75.0'
   postJob:

--- a/resources/helm/performance.yaml
+++ b/resources/helm/performance.yaml
@@ -726,16 +726,6 @@ mod-login-saml:
       memory: '427Mi'
     requests:
       memory: '341Mi'
-mod-marc-migrations:
-  javaOptions: '-XX:MaxRAMPercentage=85.0'
-  postJob:
-    enabled: false
-  replicaCount: 1
-  resources:
-    limits:
-      memory: '1280Mi'
-    requests:
-      memory: '1024Mi'
 mod-ncip:
   javaOptions: '-XX:MaxRAMPercentage=75.0'
   postJob:

--- a/resources/helm/testing.yaml
+++ b/resources/helm/testing.yaml
@@ -726,16 +726,6 @@ mod-login-saml:
       memory: '427Mi'
     requests:
       memory: '341Mi'
-mod-marc-migrations:
-  javaOptions: '-XX:MaxRAMPercentage=85.0'
-  postJob:
-    enabled: false
-  replicaCount: 1
-  resources:
-    limits:
-      memory: '1280Mi'
-    requests:
-      memory: '1024Mi'
 mod-ncip:
   javaOptions: '-XX:MaxRAMPercentage=75.0'
   postJob:

--- a/resources/slackNotificationsTemplates/karateTemplates/failureTemplate
+++ b/resources/slackNotificationsTemplates/karateTemplates/failureTemplate
@@ -7,6 +7,11 @@
             "type": "button",
             "text": "*Check out the tests report* :bar_chart: ",
             "url": "$BUILD_URLcucumber-html-reports/overview-features.html",
+        },
+        {
+                    "type": "button",
+                    "text": "*ReportPortal results* :bar_chart: ",
+                    "url": "https://poc-report-portal.ci.folio.org/ui/#login",
         }
   ]
 }

--- a/resources/slackNotificationsTemplates/karateTemplates/successTemplate
+++ b/resources/slackNotificationsTemplates/karateTemplates/successTemplate
@@ -7,6 +7,11 @@
             "type": "button",
             "text": "*Check out the tests report* :bar_chart: ",
             "url": "$BUILD_URLcucumber-html-reports/overview-features.html",
+        },
+        {
+            "type": "button",
+            "text": "*ReportPortal results* :bar_chart: ",
+            "url": "https://poc-report-portal.ci.folio.org/ui/#login",
         }
   ]
 }

--- a/src/org/folio/rest/GitHubUtility.groovy
+++ b/src/org/folio/rest/GitHubUtility.groovy
@@ -76,4 +76,8 @@ class GitHubUtility implements Serializable {
     static Map getEdgeModulesMap(Map install_map){
         return install_map.findAll{it.key.startsWith("edge-")}
     }
+
+    static Map getUIModulesMap(Map install_map){
+      return install_map.findAll{it.key.startsWith("folio_")}
+    }
 }

--- a/src/org/folio/rest/GitHubUtility.groovy
+++ b/src/org/folio/rest/GitHubUtility.groovy
@@ -76,8 +76,4 @@ class GitHubUtility implements Serializable {
     static Map getEdgeModulesMap(Map install_map){
         return install_map.findAll{it.key.startsWith("edge-")}
     }
-
-    static Map getUIModulesMap(Map install_map){
-      return install_map.findAll{it.key.startsWith("folio_")}
-    }
 }

--- a/src/org/folio/rest_v2/Main.groovy
+++ b/src/org/folio/rest_v2/Main.groovy
@@ -26,8 +26,7 @@ class Main extends Okapi {
     void preInstallUI(List installJson) {
       publishModulesDescriptors(getUnregisteredModuleDescriptors(installJson))
     }
-
-
+  
     void simulateInstall(OkapiTenant tenant, Object installJson) {
         if (!tenant.getInstallRequestParams().getSimulate()) {
             logger.warning("Simulation not requested!")

--- a/src/org/folio/rest_v2/Main.groovy
+++ b/src/org/folio/rest_v2/Main.groovy
@@ -26,7 +26,7 @@ class Main extends Okapi {
     void preInstallUI(List installJson) {
       publishModulesDescriptors(getUnregisteredModuleDescriptors(installJson))
     }
-  
+
     void simulateInstall(OkapiTenant tenant, Object installJson) {
         if (!tenant.getInstallRequestParams().getSimulate()) {
             logger.warning("Simulation not requested!")

--- a/src/org/folio/rest_v2/Main.groovy
+++ b/src/org/folio/rest_v2/Main.groovy
@@ -23,6 +23,11 @@ class Main extends Okapi {
         publishServiceDiscovery(discoveryList)
     }
 
+    void preInstallUI(List installJson) {
+      publishModulesDescriptors(getUnregisteredModuleDescriptors(installJson))
+    }
+
+
     void simulateInstall(OkapiTenant tenant, Object installJson) {
         if (!tenant.getInstallRequestParams().getSimulate()) {
             logger.warning("Simulation not requested!")

--- a/vars/common.groovy
+++ b/vars/common.groovy
@@ -1,5 +1,6 @@
 import groovy.json.JsonSlurperClassic
 import org.folio.Constants
+import org.folio.rest.model.OkapiTenant
 import org.folio.utilities.HttpClient
 import org.folio.utilities.Logger
 import org.folio.utilities.Tools
@@ -26,11 +27,15 @@ static String generateDomain(String cluster_name, String project_name, String pr
 }
 
 // A function that waits for a service to be available.
-void healthCheck(String url, String status_codes='200,403'){
+void healthCheck(String url, String status_codes='200,403', OkapiTenant tenant){
     timeout(15) {
         waitUntil(initialRecurrencePeriod: 20000, quiet: true) {
             try {
-                httpRequest ignoreSslErrors: true, quiet: true, responseHandle: 'NONE', timeout: 1000, url: url, validResponseCodes: status_codes
+                ArrayList headers = [
+                    [name: 'X-Okapi-Tenant', value: tenant.getId()],
+                    [name: 'X-Okapi-Token', value: tenant.getAdminUser().getToken() ? tenant.getAdminUser().getToken() : '', maskValue: true]
+                ]
+                httpRequest ignoreSslErrors: true, quiet: true, responseHandle: 'NONE', timeout: 1000, url: url, validResponseCodes: status_codes, customHeaders: headers
                 return true
             } catch (exception) {
                 println(exception.getMessage())

--- a/vars/common.groovy
+++ b/vars/common.groovy
@@ -1,6 +1,5 @@
 import groovy.json.JsonSlurperClassic
 import org.folio.Constants
-import org.folio.rest.model.OkapiTenant
 import org.folio.utilities.HttpClient
 import org.folio.utilities.Logger
 import org.folio.utilities.Tools
@@ -27,15 +26,11 @@ static String generateDomain(String cluster_name, String project_name, String pr
 }
 
 // A function that waits for a service to be available.
-void healthCheck(String url, String status_codes='200,403', OkapiTenant tenant){
+void healthCheck(String url, String status_codes='200,403'){
     timeout(15) {
         waitUntil(initialRecurrencePeriod: 20000, quiet: true) {
             try {
-                ArrayList headers = [
-                    [name: 'X-Okapi-Tenant', value: tenant.getId()],
-                    [name: 'X-Okapi-Token', value: tenant.getAdminUser().getToken() ? tenant.getAdminUser().getToken() : '', maskValue: true]
-                ]
-                httpRequest ignoreSslErrors: true, quiet: true, responseHandle: 'NONE', timeout: 1000, url: url, validResponseCodes: status_codes, customHeaders: headers
+              httpRequest ignoreSslErrors: true, quiet: true, responseHandle: 'NONE', timeout: 1000, url: url, validResponseCodes: status_codes
                 return true
             } catch (exception) {
                 println(exception.getMessage())

--- a/vars/common.groovy
+++ b/vars/common.groovy
@@ -30,7 +30,7 @@ void healthCheck(String url, String status_codes='200,403'){
     timeout(15) {
         waitUntil(initialRecurrencePeriod: 20000, quiet: true) {
             try {
-              httpRequest ignoreSslErrors: true, quiet: true, responseHandle: 'NONE', timeout: 1000, url: url, validResponseCodes: status_codes
+                httpRequest ignoreSslErrors: true, quiet: true, responseHandle: 'NONE', timeout: 1000, url: url, validResponseCodes: status_codes
                 return true
             } catch (exception) {
                 println(exception.getMessage())

--- a/vars/folioHelm.groovy
+++ b/vars/folioHelm.groovy
@@ -45,8 +45,6 @@ void deployFolioModule(RancherNamespace ns, String moduleName, String moduleVers
     String valuesFilePath = ""
     String releaseName = moduleName
     String chartName = moduleName
-    println(releaseName)
-    println(chartName)
     switch (moduleName) {
         case "okapi":
             valuesFilePath = generateModuleValues(ns, moduleName, moduleVersion, ns.domains['okapi'], customModule)

--- a/vars/folioHelm.groovy
+++ b/vars/folioHelm.groovy
@@ -17,8 +17,12 @@ void withK8sClient(Closure closure) {
 
 void withKubeConfig(String clusterName, Closure closure) {
     withK8sClient {
+        println(clusterName)
+        println(closure)
         awscli.getKubeConfig(Constants.AWS_REGION, clusterName)
         addHelmRepository(Constants.FOLIO_HELM_V2_REPO_NAME, Constants.FOLIO_HELM_V2_REPO_URL, true)
+        println(clusterName)
+        println(closure)
         closure.call()
     }
 }
@@ -45,6 +49,10 @@ void deployFolioModule(RancherNamespace ns, String moduleName, String moduleVers
     String valuesFilePath = ""
     String releaseName = moduleName
     String chartName = moduleName
+    println(ns)
+    println(moduleName)
+    println(moduleVersion)
+    println(tenantId)
     switch (moduleName) {
         case "okapi":
             valuesFilePath = generateModuleValues(ns, moduleName, moduleVersion, ns.domains['okapi'], customModule)

--- a/vars/folioHelm.groovy
+++ b/vars/folioHelm.groovy
@@ -64,9 +64,6 @@ void deployFolioModule(RancherNamespace ns, String moduleName, String moduleVers
             new Logger(this, "folioHelm").warning("${moduleName} is not a folio or known module")
             break
     }
-
-  // Debugging: Print values before calling upgrade
-  System.out.println("Calling upgrade with: releaseName=" + releaseName + ", chartName=" + chartName + ", valuesFilePath=" + valuesFilePath);
     upgrade(releaseName, ns.namespaceName, valuesFilePath, Constants.FOLIO_HELM_V2_REPO_NAME, chartName)
 }
 

--- a/vars/folioHelm.groovy
+++ b/vars/folioHelm.groovy
@@ -45,6 +45,8 @@ void deployFolioModule(RancherNamespace ns, String moduleName, String moduleVers
     String valuesFilePath = ""
     String releaseName = moduleName
     String chartName = moduleName
+    println(releaseName)
+    println(chartName)
     switch (moduleName) {
         case "okapi":
             valuesFilePath = generateModuleValues(ns, moduleName, moduleVersion, ns.domains['okapi'], customModule)

--- a/vars/folioHelm.groovy
+++ b/vars/folioHelm.groovy
@@ -64,6 +64,9 @@ void deployFolioModule(RancherNamespace ns, String moduleName, String moduleVers
             new Logger(this, "folioHelm").warning("${moduleName} is not a folio or known module")
             break
     }
+
+  // Debugging: Print values before calling upgrade
+  System.out.println("Calling upgrade with: releaseName=" + releaseName + ", chartName=" + chartName + ", valuesFilePath=" + valuesFilePath);
     upgrade(releaseName, ns.namespaceName, valuesFilePath, Constants.FOLIO_HELM_V2_REPO_NAME, chartName)
 }
 

--- a/vars/folioHelm.groovy
+++ b/vars/folioHelm.groovy
@@ -17,12 +17,8 @@ void withK8sClient(Closure closure) {
 
 void withKubeConfig(String clusterName, Closure closure) {
     withK8sClient {
-        println(clusterName)
-        println(closure)
         awscli.getKubeConfig(Constants.AWS_REGION, clusterName)
         addHelmRepository(Constants.FOLIO_HELM_V2_REPO_NAME, Constants.FOLIO_HELM_V2_REPO_URL, true)
-        println(clusterName)
-        println(closure)
         closure.call()
     }
 }
@@ -49,10 +45,6 @@ void deployFolioModule(RancherNamespace ns, String moduleName, String moduleVers
     String valuesFilePath = ""
     String releaseName = moduleName
     String chartName = moduleName
-    println(ns)
-    println(moduleName)
-    println(moduleVersion)
-    println(tenantId)
     switch (moduleName) {
         case "okapi":
             valuesFilePath = generateModuleValues(ns, moduleName, moduleVersion, ns.domains['okapi'], customModule)

--- a/vars/folioParameters.groovy
+++ b/vars/folioParameters.groovy
@@ -1,8 +1,8 @@
 import org.folio.Constants
 import hudson.util.Secret
-import org.folio.models.OkapiConfig
-import org.folio.models.SmtpConfig
-import org.folio.rest.model.OkapiTenant
+//import org.folio.models.OkapiConfig
+//import org.folio.models.SmtpConfig
+//import org.folio.rest.model.OkapiTenant
 
 private def _paramChoice(String name, List value, String description) {
     return choice(name: name, choices: value, description: description)

--- a/vars/folioParameters.groovy
+++ b/vars/folioParameters.groovy
@@ -122,6 +122,7 @@ static List repositoriesList() {
 def pgVersion(){
   return _paramChoice('DB_VERSION', Constants.PGSQL_VERSION, 'Select PostgreSQL version')
 }
+
 static String getUIImagesList() {
   return """
 import com.amazonaws.client.builder.AwsClientBuilder;

--- a/vars/folioParameters.groovy
+++ b/vars/folioParameters.groovy
@@ -1,5 +1,7 @@
 import org.folio.Constants
 import hudson.util.Secret
+import org.folio.models.OkapiConfig
+import org.folio.models.SmtpConfig
 import org.folio.rest.model.OkapiTenant
 
 private def _paramChoice(String name, List value, String description) {
@@ -111,7 +113,7 @@ def uiBundleTag() {
   return _paramExtendedSingleSelect('UI_BUNDLE_TAG', 'CLUSTER,NAMESPACE', getUIImagesList(), 'Choose image tag for UI')
 }
 
-def tenantId(String tenant_id = defaultTenant().id) {
+def tenantId(String tenant_id = folioDefault.tenants()['diku']) {
   return _paramString('TENANT_ID', tenant_id, 'Id used for tenant creation')
 }
 
@@ -148,20 +150,5 @@ for (image in res) {
 
 return result[0].imageTag.sort().reverse().findAll().findAll{it.startsWith(CLUSTER.trim() + '-' + NAMESPACE.trim())};
 """
-}
-
-static OkapiTenant defaultTenant() {
-  return new OkapiTenant(
-    id: 'diku',
-    name: 'Datalogisk Institut',
-    description: 'Danish Library Technology Institute',
-    tenantParameters: [
-      loadReference: false,
-      loadSample   : false
-    ],
-    queryParameters: [
-      reinstall: false
-    ]
-  )
 }
 

--- a/vars/folioParameters.groovy
+++ b/vars/folioParameters.groovy
@@ -1,8 +1,5 @@
 import org.folio.Constants
 import hudson.util.Secret
-//import org.folio.models.OkapiConfig
-//import org.folio.models.SmtpConfig
-//import org.folio.rest.model.OkapiTenant
 
 private def _paramChoice(String name, List value, String description) {
     return choice(name: name, choices: value, description: description)

--- a/vars/folioParameters.groovy
+++ b/vars/folioParameters.groovy
@@ -141,6 +141,7 @@ AmazonECR client = AmazonECRClientBuilder.standard().withRegion("us-west-2").bui
 ListImagesRequest request = new ListImagesRequest().withRepositoryName("ui-bundle");
 res = client.listImages(request);
 
+
 def result = []
 for (image in res) {
    result.add(image.getImageIds());
@@ -150,3 +151,12 @@ return result[0].imageTag.sort().reverse().findAll().findAll{it.startsWith(CLUST
 """
 }
 
+def moduleName(){
+  return _paramExtendedSingleSelect('MODULE_NAME', '', folioStringScripts.getBackendModulesList(), 'Select module')
+}
+def moduleType(){
+  return _paramChoice('VERSION_TYPE', ['release', 'preRelease'], 'Select version type')
+}
+def moduleVersion(){
+  return _paramExtendedSingleSelect('MODULE_VERSION', 'MODULE_NAME, VERSION_TYPE', folioStringScripts.getModuleVersion(), 'Select module version')
+}

--- a/vars/folioParameters.groovy
+++ b/vars/folioParameters.groovy
@@ -113,7 +113,7 @@ def uiBundleTag() {
   return _paramExtendedSingleSelect('UI_BUNDLE_TAG', 'CLUSTER,NAMESPACE', getUIImagesList(), 'Choose image tag for UI')
 }
 
-def tenantId(String tenant_id = folioDefault.tenants()['diku']) {
+def tenantId(String tenant_id = folioDefault.tenants()['diku'].tenantId) {
   return _paramString('TENANT_ID', tenant_id, 'Id used for tenant creation')
 }
 

--- a/vars/folioParameters.groovy
+++ b/vars/folioParameters.groovy
@@ -145,7 +145,7 @@ for (image in res) {
    result.add(image.getImageIds());
 }
 
-return result[0].imageTag.sort().reverse().findAll({it.startsWith(CLUSTER.trim() + '-' + NAMESPACE.trim())});
+return result[0].imageTag.sort().reverse().findAll().findAll{it.startsWith(CLUSTER.trim() + '-' + NAMESPACE.trim())};
 """
 }
 

--- a/vars/folioParameters.groovy
+++ b/vars/folioParameters.groovy
@@ -148,7 +148,7 @@ for (image in res) {
    result.add(image.getImageIds());
 }
 
-return result[0].imageTag.sort().reverse().findAll().findAll{it.startsWith(CLUSTER.trim() + '-' + NAMESPACE.trim())};
+return result[0].imageTag.sort().reverse().findAll({it.startsWith(CLUSTER.trim() + '-' + NAMESPACE.trim())});
 """
 }
 

--- a/vars/folioParameters.groovy
+++ b/vars/folioParameters.groovy
@@ -164,3 +164,4 @@ static OkapiTenant defaultTenant() {
     ]
   )
 }
+

--- a/vars/folioStringScripts.groovy
+++ b/vars/folioStringScripts.groovy
@@ -39,7 +39,6 @@ if (installJson.getResponseCode().equals(200)) {
 """
 }
 
-
 static String getModuleId(String moduleName) {
   URLConnection registry = new URL("http://folio-registry.aws.indexdata.com/_/proxy/modules?filter=${moduleName}&preRelease=only&latest=1").openConnection()
   if (registry.getResponseCode().equals(200)) {
@@ -47,4 +46,40 @@ static String getModuleId(String moduleName) {
   } else {
     throw new RuntimeException("Unable to get ${moduleName} version. Url: ${registry.getURL()}. Status code: ${registry.getResponseCode()}.")
   }
+}
+
+static String getBackendModulesList(){
+    return '''import groovy.json.JsonSlurperClassic
+String nameGroup = "moduleName"
+String patternModuleVersion = /^(?<moduleName>.*)-(?<moduleVersion>(0|[1-9]\\d*)\\.(0|[1-9]\\d*)\\.(0|[1-9]\\d*).*)$/
+def installJson = new URL('https://raw.githubusercontent.com/folio-org/platform-complete/snapshot/install.json').openConnection()
+if (installJson.getResponseCode().equals(200)) {
+    List modules_list = ['okapi']
+    new JsonSlurperClassic().parseText(installJson.getInputStream().getText())*.id.findAll { it ==~ /mod-.*|edge-.*/ }.each { value ->
+        def matcherModule = value =~ patternModuleVersion
+        assert matcherModule.matches()
+        modules_list.add(matcherModule.group(nameGroup))
+    }
+    return modules_list.sort()
+}'''
+}
+
+static String getModuleVersion(){
+    return '''import groovy.json.JsonSlurperClassic
+def versionType = ''
+switch(VERSION_TYPE){
+  case 'release':
+    versionType = 'false'
+    break
+  case 'preRelease':
+    versionType = 'only'
+    break
+  default:
+    versionType = 'only'
+    break
+}
+def moduleVersionList = new URL("http://folio-registry.aws.indexdata.com/_/proxy/modules?filter=${MODULE_NAME}&preRelease=${versionType}&order=desc&orderBy=id").openConnection()
+if (moduleVersionList.getResponseCode().equals(200)) {
+  return new JsonSlurperClassic().parseText(moduleVersionList.getInputStream().getText())*.id.collect{id -> return id - "${MODULE_NAME}-"}
+}'''
 }

--- a/vars/folioUI.groovy
+++ b/vars/folioUI.groovy
@@ -48,12 +48,3 @@ void build(params) {
     common.removeImage(params.IMAGE_NAME)
   }
 }
-
-
-//void deploy(params) {
-//  stage('Deploy UI bundle') {
-//          folioHelm.withKubeConfig(params.CLUSTER) {
-//            folioHelm.deployFolioModule(params.NAMESPACE, 'ui-bundle', params.UI_BUNDLE_TAG, false, params.TENANT_ID)
-//          }
-//        }
-//      }

--- a/vars/folioUI.groovy
+++ b/vars/folioUI.groovy
@@ -1,9 +1,9 @@
 #!groovy
 
-import groovy.json.JsonSlurperClassic
+//import groovy.json.JsonSlurperClassic
 import org.folio.Constants
-import org.folio.models.OkapiTenantConsortia
-import org.folio.models.TenantUi
+//import org.folio.models.OkapiTenantConsortia
+//import org.folio.models.TenantUi
 
 
 

--- a/vars/folioUI.groovy
+++ b/vars/folioUI.groovy
@@ -1,11 +1,6 @@
 #!groovy
 
-//import groovy.json.JsonSlurperClassic
 import org.folio.Constants
-//import org.folio.models.OkapiTenantConsortia
-//import org.folio.models.TenantUi
-
-
 
 void build(params) {
   stage('Checkout') {

--- a/vars/folioUI.groovy
+++ b/vars/folioUI.groovy
@@ -50,10 +50,10 @@ void build(params) {
 }
 
 
-void deploy(params) {
-  stage('Deploy UI bundle') {
-          folioHelm.withKubeConfig(params.CLUSTER) {
-            folioHelm.deployFolioModule(params.NAMESPACE, 'ui-bundle', params.UI_BUNDLE_TAG, false, params.TENANT_ID)
-          }
-        }
-      }
+//void deploy(params) {
+//  stage('Deploy UI bundle') {
+//          folioHelm.withKubeConfig(params.CLUSTER) {
+//            folioHelm.deployFolioModule(params.NAMESPACE, 'ui-bundle', params.UI_BUNDLE_TAG, false, params.TENANT_ID)
+//          }
+//        }
+//      }

--- a/vars/jobsParameters.groovy
+++ b/vars/jobsParameters.groovy
@@ -142,7 +142,7 @@ static String getRepositoryBranches(String repository) {
 def credentialId = "id-jenkins-github-personal-token"
 def credential = com.cloudbees.plugins.credentials.SystemCredentialsProvider.getInstance().getStore().getCredentials(com.cloudbees.plugins.credentials.domains.Domain.global()).find { it.getId().equals(credentialId) }
 def secret_value = credential.getSecret().getPlainText()
-def get = new URL('https://api.github.com/repos/folio-org/' + ${repository} + '/branches?per_page=100')
+def get = new URL('https://api.github.com/repos/folio-org/' + ${repository} + '/branches?per_page=200')
 HttpURLConnection conn = (HttpURLConnection) get.openConnection()
 conn.setRequestProperty("Authorization","Bearer "+" \${secret_value}");
 if(conn.responseCode.equals(200)){

--- a/vars/jobsParameters.groovy
+++ b/vars/jobsParameters.groovy
@@ -176,6 +176,7 @@ def fetchBranches = { String url ->
     }
     return branches
 }
+fetchBranches("\$apiUrl?per_page=\$perPage")
 """
 }
 

--- a/vars/jobsParameters.groovy
+++ b/vars/jobsParameters.groovy
@@ -143,7 +143,7 @@ def credential = com.cloudbees.plugins.credentials.SystemCredentialsProvider.get
 def secret_value = credential.getSecret().getPlainText()
 def get = new URL('https://api.github.com/repos/folio-org/' + ${repository} + '/branches?per_page=100')
 HttpURLConnection conn = (HttpURLConnection) get.openConnection()
-conn.setRequestProperty("Authorization","Bearer "+" \\${secret_value}");
+conn.setRequestProperty("Authorization","Bearer "+" \${secret_value}");
 if(conn.responseCode.equals(200)){
   return new JsonSlurperClassic().parseText(conn.getInputStream().getText()).name
 }

--- a/vars/jobsParameters.groovy
+++ b/vars/jobsParameters.groovy
@@ -142,12 +142,41 @@ static String getRepositoryBranches(String repository) {
 def credentialId = "id-jenkins-github-personal-token"
 def credential = com.cloudbees.plugins.credentials.SystemCredentialsProvider.getInstance().getStore().getCredentials(com.cloudbees.plugins.credentials.domains.Domain.global()).find { it.getId().equals(credentialId) }
 def secret_value = credential.getSecret().getPlainText()
-def get = new URL('https://api.github.com/repos/folio-org/' + ${repository} + '/branches?per_page=200')
-HttpURLConnection conn = (HttpURLConnection) get.openConnection()
-conn.setRequestProperty("Authorization","Bearer "+" \${secret_value}");
-if(conn.responseCode.equals(200)){
-  return new JsonSlurperClassic().parseText(conn.getInputStream().getText()).name
+def apiUrl = "https://api.github.com/repos/folio-org/ + ${repository} + /branches"
+def perPage = 500
+def fetchBranches = { String url ->
+    def branches = []
+    def getNextPage = { nextPageUrl ->
+        def nextConn = new URL(nextPageUrl).openConnection()
+        nextConn.setRequestProperty("Authorization", "Bearer \${secret_value}")
+        if (nextConn.responseCode.equals(200)) {
+            def nextResponseText = nextConn.getInputStream().getText()
+            branches += new JsonSlurperClassic().parseText(nextResponseText).name
+            def nextLinkHeader = nextConn.getHeaderField("Link")
+            if (nextLinkHeader && nextLinkHeader.contains('rel="next"')) {
+                def nextUrl = nextLinkHeader =~ /<(.*?)>/
+                if (nextUrl) {
+                    getNextPage(nextUrl[0][1])
+                }
+            }
+        }
+    }
+    def conn = new URL(url).openConnection()
+    conn.setRequestProperty("Authorization", "Bearer \${secret_value}")
+    if (conn.responseCode.equals(200)) {
+        def responseText = conn.getInputStream().getText()
+        branches += new JsonSlurperClassic().parseText(responseText).name
+        def linkHeader = conn.getHeaderField("Link")
+        if (linkHeader && linkHeader.contains('rel="next"')) {
+            def nextPageUrl = linkHeader =~ /<(.*?)>/
+            if (nextPageUrl) {
+                getNextPage(nextPageUrl[0][1])
+            }
+        }
+    }
+    return branches
 }
+fetchBranches("\$apiUrl?per_page=\$perPage")
 """
 }
 

--- a/vars/jobsParameters.groovy
+++ b/vars/jobsParameters.groovy
@@ -86,7 +86,6 @@ static List devEnvironmentsList() {
             'bulk-edit',
             'concorde',
             'consortia',
-            'corsair',
             'core-platform',
             'data-migration',
             'falcon',
@@ -142,41 +141,12 @@ static String getRepositoryBranches(String repository) {
 def credentialId = "id-jenkins-github-personal-token"
 def credential = com.cloudbees.plugins.credentials.SystemCredentialsProvider.getInstance().getStore().getCredentials(com.cloudbees.plugins.credentials.domains.Domain.global()).find { it.getId().equals(credentialId) }
 def secret_value = credential.getSecret().getPlainText()
-def apiUrl = "https://api.github.com/repos/folio-org/" + ${repository} + "/branches"
-def perPage = 500
-def fetchBranches = { String url ->
-    def branches = []
-    def getNextPage = { nextPageUrl ->
-        def nextConn = new URL(nextPageUrl).openConnection()
-        nextConn.setRequestProperty("Authorization", "Bearer \${secret_value}")
-        if (nextConn.responseCode.equals(200)) {
-            def nextResponseText = nextConn.getInputStream().getText()
-            branches += new JsonSlurperClassic().parseText(nextResponseText).name
-            def nextLinkHeader = nextConn.getHeaderField("Link")
-            if (nextLinkHeader && nextLinkHeader.contains('rel="next"')) {
-                def nextUrl = nextLinkHeader =~ /<(.*?)>/
-                if (nextUrl) {
-                    getNextPage(nextUrl[0][1])
-                }
-            }
-        }
-    }
-    def conn = new URL(url).openConnection()
-    conn.setRequestProperty("Authorization", "Bearer \${secret_value}")
-    if (conn.responseCode.equals(200)) {
-        def responseText = conn.getInputStream().getText()
-        branches += new JsonSlurperClassic().parseText(responseText).name
-        def linkHeader = conn.getHeaderField("Link")
-        if (linkHeader && linkHeader.contains('rel="next"')) {
-            def nextPageUrl = linkHeader =~ /<(.*?)>/
-            if (nextPageUrl) {
-                getNextPage(nextPageUrl[0][1])
-            }
-        }
-    }
-    return branches
+def get = new URL('https://api.github.com/repos/folio-org/' + ${repository} + '/branches?per_page=100')
+HttpURLConnection conn = (HttpURLConnection) get.openConnection()
+conn.setRequestProperty("Authorization","Bearer "+" \\${secret_value}");
+if(conn.responseCode.equals(200)){
+  return new JsonSlurperClassic().parseText(conn.getInputStream().getText()).name
 }
-fetchBranches("\$apiUrl?per_page=\$perPage")
 """
 }
 

--- a/vars/jobsParameters.groovy
+++ b/vars/jobsParameters.groovy
@@ -142,7 +142,7 @@ static String getRepositoryBranches(String repository) {
 def credentialId = "id-jenkins-github-personal-token"
 def credential = com.cloudbees.plugins.credentials.SystemCredentialsProvider.getInstance().getStore().getCredentials(com.cloudbees.plugins.credentials.domains.Domain.global()).find { it.getId().equals(credentialId) }
 def secret_value = credential.getSecret().getPlainText()
-def apiUrl = "https://api.github.com/repos/folio-org/ + ${repository} + /branches"
+def apiUrl = "https://api.github.com/repos/folio-org/" + ${repository} + "/branches"
 def perPage = 500
 def fetchBranches = { String url ->
     def branches = []
@@ -176,7 +176,6 @@ def fetchBranches = { String url ->
     }
     return branches
 }
-fetchBranches("\$apiUrl?per_page=\$perPage")
 """
 }
 


### PR DESCRIPTION
Changes during task is in files:
pipelines/folioRancher/folioDevTools/uiManagement/deployUI/Jenkinsfile => stage Update UI Modules
src/org/folio/rest_v2/Main.groovy
============
ui-bundle-deploy job doesn't automatically publish UI module descriptors and doesn't register new version with okapi. Because of this any permission changes are not applied.
It would be very helpful to have this job automatically register UI modules in okapi and update module permissions.
If that cannot be done in ui-bundle-deploy job, or if it will significantly increase build time - perhaps a separate job for this task can be created?
