### PR TITLE
.RANCHER-1239 align msk version in sts variant.

### DIFF
--- a/terraform/rancher/project/kafka.tf
+++ b/terraform/rancher/project/kafka.tf
@@ -10,7 +10,7 @@ resource "rancher2_app_v2" "kafka" {
   force_upgrade = "true"
   values        = <<-EOT
     image:
-      tag: 2.8
+      tag: 3.5
     metrics:
       kafka:
         enabled: true
@@ -65,7 +65,7 @@ resource "rancher2_app_v2" "kafka_ui" {
   name          = "kafka-ui"
   repo_name     = "provectus"
   chart_name    = "kafka-ui"
-  chart_version = "0.7.1"
+  chart_version = "0.7.2"
   force_upgrade = "true"
   values        = <<-EOT
     service:
@@ -93,8 +93,8 @@ resource "rancher2_app_v2" "kafka_ui" {
             enabled: false
       resources:
         requests:
-          memory: 256Mi
+          memory: 512Mi
         limits:
-          memory: 768Mi
+          memory: 2048Mi
   EOT
 }


### PR DESCRIPTION
NOTE: Zookeeper version is compatible and will preserve previous version backward compatibility, chart version should stay AS IS.