### PR TITLE
RANCHER-1270

### DIFF
--- a/pipelines/folioRancher/folioNamespaceTools/manageNamespace/createNamespaceFromBranch/Jenkinsfile
+++ b/pipelines/folioRancher/folioNamespaceTools/manageNamespace/createNamespaceFromBranch/Jenkinsfile
@@ -13,9 +13,9 @@ import org.jenkinsci.plugins.workflow.libs.Library
 
 //TODO remove branch before merge to master
 
-@Library('pipelines-shared-library@RANCHER-741-Jenkins-Enhancements') _
+@Library('pipelines-shared-library@RANCHER-1270') _
 
-CONFIG_BRANCH = 'RANCHER-741-Jenkins-Enhancements'
+CONFIG_BRANCH = 'RANCHER-1270'
 
 properties([
   buildDiscarder(logRotator(numToKeepStr: '30')),

--- a/pipelines/folioRancher/folioNamespaceTools/manageNamespace/createNamespaceFromBranch/Jenkinsfile
+++ b/pipelines/folioRancher/folioNamespaceTools/manageNamespace/createNamespaceFromBranch/Jenkinsfile
@@ -13,9 +13,9 @@ import org.jenkinsci.plugins.workflow.libs.Library
 
 //TODO remove branch before merge to master
 
-@Library('pipelines-shared-library@RANCHER-1270') _
+@Library('pipelines-shared-library@RANCHER-741-Jenkins-Enhancements') _
 
-CONFIG_BRANCH = 'RANCHER-1270'
+CONFIG_BRANCH = 'RANCHER-741-Jenkins-Enhancements'
 
 properties([
   buildDiscarder(logRotator(numToKeepStr: '30')),

--- a/terraform/rancher/project/postgresql.tf
+++ b/terraform/rancher/project/postgresql.tf
@@ -105,7 +105,7 @@ resource "rancher2_app_v2" "postgresql" {
     volumePermissions:
       enabled: true
     metrics:
-      enabled: true
+      enabled: ${local.pg_auth}
       resources:
         requests:
           memory: 512Mi

--- a/terraform/rancher/project/postgresql.tf
+++ b/terraform/rancher/project/postgresql.tf
@@ -16,6 +16,7 @@ locals {
   pg_architecture   = var.enable_rw_split ? "replication" : "standalone"
   pg_service_reader = var.enable_rw_split ? "postgresql-${var.rancher_project_name}-read" : ""
   pg_service_writer = var.enable_rw_split ? "postgresql-${var.rancher_project_name}-primary" : "postgresql-${var.rancher_project_name}"
+  pg_auth           = local.pg_architecture == "standalone" ? "true" : "false"
 }
 
 # Rancher2 Project App Postgres
@@ -59,7 +60,7 @@ resource "rancher2_app_v2" "postgresql" {
       postgresPassword: ${var.pg_password}
       replicationPassword: ${var.pg_password}
       replicationUsername: ${var.pg_username}
-      usePasswordFiles: true
+      usePasswordFiles: ${local.pg_auth}
     primary:
       initdb:
         scripts:

--- a/terraform/rancher/project/postgresql.tf
+++ b/terraform/rancher/project/postgresql.tf
@@ -16,7 +16,7 @@ locals {
   pg_architecture   = var.enable_rw_split ? "replication" : "standalone"
   pg_service_reader = var.enable_rw_split ? "postgresql-${var.rancher_project_name}-read" : ""
   pg_service_writer = var.enable_rw_split ? "postgresql-${var.rancher_project_name}-primary" : "postgresql-${var.rancher_project_name}"
-  pg_auth           = local.pg_architecture == "standalone" ? "true" : "false"
+  pg_auth           = local.pg_architecture == "replication" ? "false" : "true"
 }
 
 # Rancher2 Project App Postgres


### PR DESCRIPTION
### To whose who may be interested in:
Since we are providing env vars with creds inside, passfile option is optional, in R\W mode read replica sts deployment can't be started due to limitation on helm\tf side, i.e. diff in paths to password file:

- primary: /opt/bitnami/postgresql/secrets/postgres-password
- read: /opt/bitnami/postgresql/secrets/password 

by that metrics container can't start on read replica deployment side, causing an issue, original message helm chart can't re-use name blah blah blah, is not related to the issue, it was just our script's second attempt the perform TF apply operation.

P\S seems like that R\W in hosted variant had never been in working state.
Successful env build job: https://jenkins-aws.indexdata.com/job/folioRancher/job/tmpFolderForDraftPipelines/job/createNamespaceFromBranch-1270/2/console 