### PR TITLE
RANCHER-1365. Refactoring and unification of the process of collecting test execution results for various test frameworks in the common Jenkins library for different test frameworks. part #1

### DIFF
--- a/pipelines/folioRancher/folioScheduledTesting/karateTestsScheduledPipeline.groovy
+++ b/pipelines/folioRancher/folioScheduledTesting/karateTestsScheduledPipeline.groovy
@@ -1,7 +1,7 @@
 @Library('pipelines-shared-library@RANCHER-741-Jenkins-Enhancements') _
 
-import org.folio.karate.results.KarateTestsExecutionSummary
-import org.folio.karate.teams.TeamAssignment
+import org.folio.testing.karate.results.KarateTestsExecutionSummary
+import org.folio.testing.teams.TeamAssignment
 import org.folio.utilities.Tools
 import org.jenkinsci.plugins.workflow.libs.Library
 

--- a/src/org/folio/jira/JiraClient.groovy
+++ b/src/org/folio/jira/JiraClient.groovy
@@ -11,7 +11,7 @@ import org.folio.jira.model.JiraPriority
 import org.folio.jira.model.JiraProject
 import org.folio.jira.model.JiraResources
 import org.folio.jira.model.JiraStatus
-import org.folio.karate.KarateConstants
+import org.folio.testing.karate.KarateConstants
 
 import java.util.logging.Logger
 

--- a/src/org/folio/testing/cypress/CypressConstants.groovy
+++ b/src/org/folio/testing/cypress/CypressConstants.groovy
@@ -1,0 +1,6 @@
+package org.folio.testing.cypress
+
+class CypressConstants {
+
+//TBD
+}

--- a/src/org/folio/testing/cypress/results/CypressTestsExecutionSummary.groovy
+++ b/src/org/folio/testing/cypress/results/CypressTestsExecutionSummary.groovy
@@ -1,0 +1,15 @@
+package org.folio.testing.cypress.results
+
+import org.folio.testing.karate.results.KarateModuleExecutionSummary
+
+class CypressTestsExecutionSummary {
+
+//TBD
+
+  @Override
+  public String toString() {
+    return "CypressTestsResult{" +
+      "modulesTestResult=" + modulesExecutionSummary +
+      '}';
+  }
+}

--- a/src/org/folio/testing/karate/KarateConstants.groovy
+++ b/src/org/folio/testing/karate/KarateConstants.groovy
@@ -1,4 +1,4 @@
-package org.folio.karate
+package org.folio.testing.karate
 
 class KarateConstants {
 

--- a/src/org/folio/testing/karate/results/KarateExecutionResult.groovy
+++ b/src/org/folio/testing/karate/results/KarateExecutionResult.groovy
@@ -1,4 +1,4 @@
-package org.folio.karate.results
+package org.folio.testing.karate.results
 
 enum KarateExecutionResult {
 

--- a/src/org/folio/testing/karate/results/KarateFeatureExecutionSummary.groovy
+++ b/src/org/folio/testing/karate/results/KarateFeatureExecutionSummary.groovy
@@ -1,4 +1,4 @@
-package org.folio.karate.results
+package org.folio.testing.karate.results
 
 class KarateFeatureExecutionSummary {
 

--- a/src/org/folio/testing/karate/results/KarateModuleExecutionSummary.groovy
+++ b/src/org/folio/testing/karate/results/KarateModuleExecutionSummary.groovy
@@ -1,4 +1,4 @@
-package org.folio.karate.results
+package org.folio.testing.karate.results
 
 class KarateModuleExecutionSummary {
 

--- a/src/org/folio/testing/karate/results/KarateTestsExecutionSummary.groovy
+++ b/src/org/folio/testing/karate/results/KarateTestsExecutionSummary.groovy
@@ -1,4 +1,4 @@
-package org.folio.karate.results
+package org.folio.testing.karate.results
 
 class KarateTestsExecutionSummary {
 

--- a/src/org/folio/testing/teams/Team.groovy
+++ b/src/org/folio/testing/teams/Team.groovy
@@ -1,8 +1,8 @@
-package org.folio.karate.teams
+package org.folio.testing.teams
 
 import com.cloudbees.groovy.cps.NonCPS
 
-class KarateTeam {
+class Team {
 
     String name
 
@@ -15,7 +15,7 @@ class KarateTeam {
         if (this.is(o)) return true
         if (getClass() != o.class) return false
 
-        KarateTeam that = (KarateTeam) o
+        Team that = (Team) o
 
         if (modules != that.modules) return false
         if (name != that.name) return false

--- a/src/org/folio/testing/teams/TeamAssignment.groovy
+++ b/src/org/folio/testing/teams/TeamAssignment.groovy
@@ -1,19 +1,19 @@
-package org.folio.karate.teams
+package org.folio.testing.teams
 
 class TeamAssignment {
 
-    List<KarateTeam> teams = []
+    List<Team> teams = []
 
     TeamAssignment(def jsonContents) {
         jsonContents.each { entry ->
-            KarateTeam team = new KarateTeam(name: entry.team, slackChannel: entry.slackChannel)
+            Team team = new Team(name: entry.team, slackChannel: entry.slackChannel)
             team.getModules().addAll(entry.modules)
             teams.add(team)
         }
     }
 
-    Map<String, KarateTeam> getTeamsByModules() {
-        Map<String, KarateTeam> retVal = [:]
+    Map<String, Team> getTeamsByModules() {
+        Map<String, Team> retVal = [:]
         teams.each {team ->
             team.modules.each {module ->
                 retVal[module] = team

--- a/test/unit/groovy/vars/KarateTestsUtils.groovy
+++ b/test/unit/groovy/vars/KarateTestsUtils.groovy
@@ -4,10 +4,10 @@ package vars
 import groovy.json.JsonSlurper
 import jenkins.plugins.http_request.ResponseContentSupplier
 import org.folio.jira.JiraConstants
-import org.folio.karate.results.KarateFeatureExecutionSummary
-import org.folio.karate.results.KarateModuleExecutionSummary
-import org.folio.karate.results.KarateTestsExecutionSummary
-import org.folio.karate.teams.TeamAssignment
+import org.folio.testing.karate.results.KarateFeatureExecutionSummary
+import org.folio.testing.karate.results.KarateModuleExecutionSummary
+import org.folio.testing.karate.results.KarateTestsExecutionSummary
+import org.folio.testing.teams.TeamAssignment
 import org.folio.testharness.AbstractScriptTest
 import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.Test

--- a/test/unit/resources/vars/KarateTestsUtils_script.groovy
+++ b/test/unit/resources/vars/KarateTestsUtils_script.groovy
@@ -1,5 +1,5 @@
-import org.folio.karate.results.KarateTestsExecutionSummary
-import org.folio.karate.teams.TeamAssignment
+import org.folio.testing.karate.results.KarateTestsExecutionSummary
+import org.folio.testing.teams.TeamAssignment
 import org.jenkinsci.plugins.workflow.libs.Library
 
 def execute(KarateTestsExecutionSummary karateTestsExecutionSummary, TeamAssignment teamAssignment) {

--- a/vars/dataMigrationReport.groovy
+++ b/vars/dataMigrationReport.groovy
@@ -8,7 +8,7 @@ import org.folio.utilities.Tools
 import org.folio.jira.JiraClient
 import org.folio.jira.model.JiraIssue
 import org.folio.Constants
-import org.folio.karate.teams.TeamAssignment
+import org.folio.testing.teams.TeamAssignment
 
 def getESLogs(cluster, indexPattern, startDate) {
     def template = "get-logs-ES.json.template"

--- a/vars/folioSchemaCompareUtils.groovy
+++ b/vars/folioSchemaCompareUtils.groovy
@@ -3,7 +3,7 @@ import groovy.xml.MarkupBuilder
 import org.folio.Constants
 import org.folio.jira.JiraClient
 import org.folio.jira.model.JiraIssue
-import org.folio.karate.teams.TeamAssignment
+import org.folio.testing.teams.TeamAssignment
 import org.folio.utilities.Tools
 
 void getSchemasDifference(rancher_project_name, tenant_id, tenant_id_clean, pgadminURL, resultMap, diff) {

--- a/vars/karateTestUtils.groovy
+++ b/vars/karateTestUtils.groovy
@@ -2,12 +2,12 @@ import groovy.text.SimpleTemplateEngine
 import org.folio.Constants
 import org.folio.jira.JiraClient
 import org.folio.jira.model.JiraIssue
-import org.folio.karate.KarateConstants
-import org.folio.karate.results.KarateFeatureExecutionSummary
-import org.folio.karate.results.KarateModuleExecutionSummary
-import org.folio.karate.results.KarateTestsExecutionSummary
-import org.folio.karate.teams.KarateTeam
-import org.folio.karate.teams.TeamAssignment
+import org.folio.testing.karate.KarateConstants
+import org.folio.testing.karate.results.KarateFeatureExecutionSummary
+import org.folio.testing.karate.results.KarateModuleExecutionSummary
+import org.folio.testing.karate.results.KarateTestsExecutionSummary
+import org.folio.testing.teams.Team
+import org.folio.testing.teams.TeamAssignment
 
 /**
  * Collect karate tests execution statistics based on "karate-summary-json.txt" files content
@@ -170,7 +170,7 @@ String toSearchableSummary(String summary) {
  * @param jiraClient jira client
  */
 void createFailedFeatureJiraIssue(KarateModuleExecutionSummary moduleSummary, KarateFeatureExecutionSummary featureSummary,
-                                  Map<String, KarateTeam> teamByModule, JiraClient jiraClient) {
+                                  Map<String, Team> teamByModule, JiraClient jiraClient) {
     def summary = "${KarateConstants.ISSUE_SUMMARY_PREFIX} ${featureSummary.displayName}"
     String description = getIssueDescription(featureSummary)
 

--- a/vars/slackNotifications.groovy
+++ b/vars/slackNotifications.groovy
@@ -1,11 +1,11 @@
 import groovy.json.JsonOutput
 import groovy.json.JsonSlurper
 import org.folio.client.reportportal.ReportPortalTestType
-import org.folio.karate.results.KarateExecutionResult
-import org.folio.karate.results.KarateModuleExecutionSummary
-import org.folio.karate.results.KarateTestsExecutionSummary
-import org.folio.karate.teams.KarateTeam
-import org.folio.karate.teams.TeamAssignment
+import org.folio.testing.karate.results.KarateExecutionResult
+import org.folio.testing.karate.results.KarateModuleExecutionSummary
+import org.folio.testing.karate.results.KarateTestsExecutionSummary
+import org.folio.testing.teams.Team
+import org.folio.testing.teams.TeamAssignment
 import org.folio.shared.TestType
 
 @Deprecated
@@ -125,7 +125,7 @@ def renderSlackMessage(TestType testType, buildStatus, testsStatus, message, boo
 @Deprecated
 void sendKarateTeamSlackNotification(KarateTestsExecutionSummary karateTestsExecutionSummary, TeamAssignment teamAssignment) {
     // collect modules tests execution results by team
-    Map<KarateTeam, List<KarateModuleExecutionSummary>> teamResults = [:]
+    Map<Team, List<KarateModuleExecutionSummary>> teamResults = [:]
     def teamByModule = teamAssignment.getTeamsByModules()
     karateTestsExecutionSummary.getModulesExecutionSummary().values().each { moduleExecutionSummary ->
         if (teamByModule.containsKey(moduleExecutionSummary.getName())) {


### PR DESCRIPTION
This pull request includes minor changes that aim to organize different test framework integrations in a common folder called "testing". 

The following changes were made:

1. Added a new folder named "testing".
2. Created a "cypress" folder inside the "testing" folder.
3. Rebased Karate tests to the "testing" folder.
4. Separated the "teams" folder from Karate tests.
5. Renamed the "TeamKarate" class to "Team".