### PR TITLE
RANCHER-1417 | mod-data-export-worker | FIX

### DIFF
--- a/pipelines/folioRancher/folioNamespaceTools/manageNamespace/createNamespaceFromBranch/Jenkinsfile
+++ b/pipelines/folioRancher/folioNamespaceTools/manageNamespace/createNamespaceFromBranch/Jenkinsfile
@@ -13,9 +13,9 @@ import org.jenkinsci.plugins.workflow.libs.Library
 
 //TODO remove branch before merge to master
 
-@Library('pipelines-shared-library@RANCHER-741-Jenkins-Enhancements') _
+@Library('pipelines-shared-library@RANCHER-1417') _
 
-CONFIG_BRANCH = 'RANCHER-741-Jenkins-Enhancements'
+CONFIG_BRANCH = 'RANCHER-1417'
 
 properties([
   buildDiscarder(logRotator(numToKeepStr: '30')),

--- a/pipelines/folioRancher/folioNamespaceTools/manageNamespace/createNamespaceFromBranch/Jenkinsfile
+++ b/pipelines/folioRancher/folioNamespaceTools/manageNamespace/createNamespaceFromBranch/Jenkinsfile
@@ -13,9 +13,9 @@ import org.jenkinsci.plugins.workflow.libs.Library
 
 //TODO remove branch before merge to master
 
-@Library('pipelines-shared-library@RANCHER-1417') _
+@Library('pipelines-shared-library@RANCHER-741-Jenkins-Enhancements') _
 
-CONFIG_BRANCH = 'RANCHER-1417'
+CONFIG_BRANCH = 'RANCHER-741-Jenkins-Enhancements'
 
 properties([
   buildDiscarder(logRotator(numToKeepStr: '30')),

--- a/terraform/rancher/project/secrets.tf
+++ b/terraform/rancher/project/secrets.tf
@@ -49,7 +49,7 @@ resource "rancher2_secret" "s3-config-data-worker" {
     AWS_BUCKET            = base64encode(join("-", [data.rancher2_cluster.this.name, var.rancher_project_name, "data-worker"]))
     AWS_ACCESS_KEY_ID     = base64encode(var.s3_embedded ? random_string.access_key[0].result : var.s3_access_key)
     AWS_SECRET_ACCESS_KEY = base64encode(var.s3_embedded ? random_password.secret_access_key[0].result : var.s3_secret_key)
-    LOCAL_FS_BUCKET       = base64encode("local-files")
+    LOCAL_FS_BUCKET       = base64encode(var.s3_embedded ? join("-", ["second", data.rancher2_cluster.this.name, var.rancher_project_name, "data-worker"]) : "local-files")
   }
 }
 

--- a/terraform/rancher/project/secrets.tf
+++ b/terraform/rancher/project/secrets.tf
@@ -49,7 +49,7 @@ resource "rancher2_secret" "s3-config-data-worker" {
     AWS_BUCKET            = base64encode(join("-", [data.rancher2_cluster.this.name, var.rancher_project_name, "data-worker"]))
     AWS_ACCESS_KEY_ID     = base64encode(var.s3_embedded ? random_string.access_key[0].result : var.s3_access_key)
     AWS_SECRET_ACCESS_KEY = base64encode(var.s3_embedded ? random_password.secret_access_key[0].result : var.s3_secret_key)
-    LOCAL_FS_BUCKET       = base64encode(var.s3_embedded ? join("-", ["second", data.rancher2_cluster.this.name, var.rancher_project_name, "data-worker"]) : "local-files")
+    LOCAL_FS_BUCKET       = base64encode(var.s3_embedded ? "local-files" : join("-", ["second", data.rancher2_cluster.this.name, var.rancher_project_name, "data-worker"]))
   }
 }
 


### PR DESCRIPTION
### Permanent fix for mod-data-export-worker via TF provisioning
**Historically all envs on our EKS cluster were created along with minio and all worked fine, current folio-testing-sprint was created with the AWS S3 to make all testing processes identical to BugFest environment.
Since "local-files" bucket not is not unique export-worker constantly reporting: Bucket already exists, failed to upload file, to mitigate this issue we are introducing a new second bucket unique name, so every env provisioned with S3 will work smoothly
P\S bucket creation IS NOT REQUIRED, module creates bucket by itself...**