### PR TITLE
Additional changes for mod-data-import & mod-authtoken default values

### DIFF
--- a/pipelines/folioRancher/folioNamespaceTools/manageNamespace/createNamespaceFromBranch/Jenkinsfile
+++ b/pipelines/folioRancher/folioNamespaceTools/manageNamespace/createNamespaceFromBranch/Jenkinsfile
@@ -13,9 +13,9 @@ import org.jenkinsci.plugins.workflow.libs.Library
 
 //TODO remove branch before merge to master
 
-@Library('pipelines-shared-library@fix-di-slicing') _
+@Library('pipelines-shared-library@RANCHER-741-Jenkins-Enhancements') _
 
-CONFIG_BRANCH = 'fix-di-slicing'
+CONFIG_BRANCH = 'RANCHER-741-Jenkins-Enhancements'
 
 properties([
   buildDiscarder(logRotator(numToKeepStr: '30')),

--- a/pipelines/folioRancher/folioNamespaceTools/manageNamespace/createNamespaceFromBranch/Jenkinsfile
+++ b/pipelines/folioRancher/folioNamespaceTools/manageNamespace/createNamespaceFromBranch/Jenkinsfile
@@ -13,9 +13,9 @@ import org.jenkinsci.plugins.workflow.libs.Library
 
 //TODO remove branch before merge to master
 
-@Library('pipelines-shared-library@RANCHER-741-Jenkins-Enhancements') _
+@Library('pipelines-shared-library@fix-di-slicing') _
 
-CONFIG_BRANCH = 'RANCHER-741-Jenkins-Enhancements'
+CONFIG_BRANCH = 'fix-di-slicing'
 
 properties([
   buildDiscarder(logRotator(numToKeepStr: '30')),

--- a/vars/folioHelm.groovy
+++ b/vars/folioHelm.groovy
@@ -173,6 +173,7 @@ String generateModuleValues(RancherNamespace ns, String moduleName, String modul
 
   if (params.S3_BUCKET == 'built-in' && moduleName == 'mod-data-import') {
     moduleConfig << [disEnabled: false]
+    println("mod-data-import slicing is bot requested...!")
   }
 
   //Enable cross tenant extra env

--- a/vars/folioHelm.groovy
+++ b/vars/folioHelm.groovy
@@ -171,6 +171,10 @@ String generateModuleValues(RancherNamespace ns, String moduleName, String modul
     moduleConfig << [consortiumEnabled: "true"]
   }
 
+  if (params.S3_BUCKET == 'built-in' && moduleName == 'mod-data-import') {
+    moduleConfig << [disEnabled: false]
+  }
+
   //Enable cross tenant extra env
   if (moduleName == 'mod-authtoken' && ns.enableConsortia) {
     moduleConfig['javaOptions'] += ' -Dallow.cross.tenant.requests=true'

--- a/vars/folioHelm.groovy
+++ b/vars/folioHelm.groovy
@@ -171,13 +171,14 @@ String generateModuleValues(RancherNamespace ns, String moduleName, String modul
     moduleConfig << [consortiumEnabled: "true"]
   }
 
+  //Override default mdi-slicing, in case of minio
   if (params.S3_BUCKET == 'built-in' && moduleName == 'mod-data-import') {
     moduleConfig << [disEnabled: false]
-    println("mod-data-import slicing is bot requested...!")
+    println("mod-data-import slicing was not requested...!")
   }
 
-  //Enable cross tenant extra env
-  if (moduleName == 'mod-authtoken' && ns.enableConsortia) {
+  //Enable cross tenant extra env as default option
+  if (moduleName == 'mod-authtoken') {
     moduleConfig['javaOptions'] += ' -Dallow.cross.tenant.requests=true'
   }
   //Enable RTR functionality with env value


### PR DESCRIPTION
### Changes:

1. Allow ECS tenants in mod-authtoken by default at any update\installs...
2. mod-data-import slicing feature override during env(ns) provisioning, if s3 == minio

![image](https://github.com/folio-org/pipelines-shared-library/assets/138369232/05493ed1-8d85-4e9e-9287-3ae532c912e8)

Testing was completed in https://jenkins-aws.indexdata.com/job/folioRancher/job/tmpFolderForDraftPipelines/job/fix-di-slicing/2/console

Thanks!