### PR TITLE
RANCHER-1456: add multipart.max limits to JAVA_OPTIONS

### DIFF
--- a/vars/folioHelm.groovy
+++ b/vars/folioHelm.groovy
@@ -181,6 +181,13 @@ String generateModuleValues(RancherNamespace ns, String moduleName, String modul
   if (moduleName == 'mod-authtoken') {
     moduleConfig['javaOptions'] += ' -Dallow.cross.tenant.requests=true'
   }
+
+  //Enable cross tenant extra env as default option
+  if (moduleName == 'mod-bulk-operations') {
+    moduleConfig['javaOptions'] += ' -Dspring.servlet.multipart.max-file-size=40MB'
+    moduleConfig['javaOptions'] += ' -Dspring.servlet.multipart.max-request-size=40MB'
+  }
+
   //Enable RTR functionality with env value
   if (params.RTR) {
     moduleConfig << [rtrEnabled: "true"]

--- a/vars/folioHelm.groovy
+++ b/vars/folioHelm.groovy
@@ -183,7 +183,7 @@ String generateModuleValues(RancherNamespace ns, String moduleName, String modul
   }
 
   //Enable cross tenant extra env as default option
-  if (moduleName == 'mod-bulk-operations') {
+  if (moduleName == 'mod-bulk-operations' && params.NAMESPACE == 'sprint') {
     moduleConfig['javaOptions'] += ' -Dspring.servlet.multipart.max-file-size=40MB'
     moduleConfig['javaOptions'] += ' -Dspring.servlet.multipart.max-request-size=40MB'
   }


### PR DESCRIPTION
Related Jira Ticket:
[It is impossible to upload file wich size is 37mb in bulk-edit section on environment "folio-testing-sprint".](https://folio-org.atlassian.net/browse/RANCHER-1456)