### PR TITLE
RANCHER-1350 Lib for publishing of Eureka application descriptor

### DIFF
--- a/src/org/folio/Constants.groovy
+++ b/src/org/folio/Constants.groovy
@@ -100,6 +100,9 @@ class Constants {
   static String ECS_EDGE_GENERAL_USERNAME = 'EBSCOEdge'
   static String ECS_EDGE_GENERAL_PASSWORD = 'edge'
 
+  //Eureka base constants
+  static  String EUREKA_REGISTRY_URL = 'https://eureka-registry.ci.folio.org/descriptors/'
+
   //SMTP
   static String EMAIL_SMTP_CREDENTIALS_ID = 'ses-smtp-rancher'
   static String EMAIL_SMTP_SERVER = 'email-smtp.us-west-2.amazonaws.com'

--- a/src/org/folio/eureka/EurekaImage.groovy
+++ b/src/org/folio/eureka/EurekaImage.groovy
@@ -84,11 +84,9 @@ class EurekaImage implements Serializable {
   void publishMD() {
     if (moduleName ==~ 'mod-*') {
       try {
-        steps.script {
-          def name = steps.sh(script: 'find target/ -name *.jar | cut -d "/" -f 2 | sed \'s/....$//\'', returnStdout: true).trim()
-          sh(script: "curl ${Constants.EUREKA_REGISTRY_URL}${name}.json --upload-file target/ModuleDescriptor.json", returnStdout: true)
-          logger.info("ModuleDescriptor: ${Constants.EUREKA_REGISTRY_URL}${name}.json")
-        }
+        def name = steps.sh(script: 'find target/ -name *.jar | cut -d "/" -f 2 | sed \'s/....$//\'', returnStdout: true).trim()
+        steps.sh(script: "curl ${Constants.EUREKA_REGISTRY_URL}${name}.json --upload-file target/ModuleDescriptor.json", returnStdout: true)
+        logger.info("ModuleDescriptor: ${Constants.EUREKA_REGISTRY_URL}${name}.json")
       } catch (Exception e) {
         logger.error("Failed to publish MD for ${moduleName}\nError: ${e.getMessage()}")
       }

--- a/src/org/folio/eureka/EurekaImage.groovy
+++ b/src/org/folio/eureka/EurekaImage.groovy
@@ -82,7 +82,7 @@ class EurekaImage implements Serializable {
   }
 
   void publishMD() {
-    if (moduleName ==~ 'mod-') {
+    if (moduleName ==~ 'mod-*') {
       try {
         steps.script {
           def name = steps.sh(script: 'find target/ -name *.jar | cut -d "/" -f 2 | sed \'s/....$//\'', returnStdout: true).trim()

--- a/src/org/folio/eureka/EurekaImage.groovy
+++ b/src/org/folio/eureka/EurekaImage.groovy
@@ -9,7 +9,6 @@ class EurekaImage implements Serializable {
   String moduleName
   String branch = 'master'
   Logger logger
-  RestClient client
 
   EurekaImage(Object context) {
     this.steps = context
@@ -87,8 +86,8 @@ class EurekaImage implements Serializable {
       try {
         steps.script {
           def name = steps.sh(script: 'find target/ -name *.jar | cut -d "/" -f 2 | sed \'s/....$//\'', returnStdout: true).trim()
-          def json = new File('target/ModuleDescriptor.json').text
-          client.upload("${Constants.EUREKA_REGISTRY_URL}${name}.json", json as File)
+          sh(script: "curl ${Constants.EUREKA_REGISTRY_URL}${name}.json --upload-file target/ModuleDescriptor.json", returnStdout: true)
+          logger.info("ModuleDescriptor: ${Constants.EUREKA_REGISTRY_URL}${name}.json")
         }
       } catch (Exception e) {
         logger.error("Failed to publish MD for ${moduleName}\nError: ${e.getMessage()}")

--- a/src/org/folio/eureka/EurekaImage.groovy
+++ b/src/org/folio/eureka/EurekaImage.groovy
@@ -2,7 +2,6 @@ package org.folio.eureka
 
 import org.folio.Constants
 import org.folio.utilities.Logger
-import org.folio.utilities.RestClient
 
 class EurekaImage implements Serializable {
   public Object steps

--- a/src/org/folio/eureka/EurekaImage.groovy
+++ b/src/org/folio/eureka/EurekaImage.groovy
@@ -82,7 +82,7 @@ class EurekaImage implements Serializable {
   }
 
   void publishMD() {
-    if (moduleName ==~ 'mod-*') {
+    if (moduleName =~ /mod-*/) {
       try {
         def name = steps.sh(script: 'find target/ -name *.jar | cut -d "/" -f 2 | sed \'s/....$//\'', returnStdout: true).trim()
         steps.sh(script: "curl ${Constants.EUREKA_REGISTRY_URL}${name}.json --upload-file target/ModuleDescriptor.json", returnStdout: true)


### PR DESCRIPTION
### Simple method to upload generated MD from mvn install
**Testing was done in: https://jenkins-aws.indexdata.com/job/folio-org/job/mod-consortia-keycloak/job/RANCHER-1350/5/console**
**Results:**
Link: https://eureka-registry.ci.folio.org/descriptors/mod-consortia-keycloak-1.5.0-SNAPSHOT.json
![image](https://github.com/folio-org/pipelines-shared-library/assets/138369232/57021bdc-2097-4645-8604-1a6d2ce94501)
![image](https://github.com/folio-org/pipelines-shared-library/assets/138369232/dc202527-a2d0-49b2-ae35-aeb779cf67e4)
