### PR TITLE
RANCHER-1374: Add final Jenkinsfile and Dockerfile for agent.

### DIFF
--- a/scripts/docker/jenkinsAgent/Dockerfile
+++ b/scripts/docker/jenkinsAgent/Dockerfile
@@ -1,0 +1,45 @@
+# Use the Jenkins agent base image
+FROM jenkins/agent:alpine-jdk17
+
+# Set environment variables to avoid user interaction during installation
+ENV DEBIAN_FRONTEND=noninteractive
+ARG terraform_ver=1.6.0
+ARG helm_ver=3.15.4
+ARG kubectl_ver=v1.28.0
+ARG kafka_ver=3.8.0
+
+# Install required packages
+USER root
+RUN apk update && \
+    apk add --no-cache \
+    aws-cli \
+    postgresql-client \
+    unzip
+# Install Terraform
+RUN curl -fsSL "https://releases.hashicorp.com/terraform/${terraform_ver}/terraform_${terraform_ver}_linux_amd64.zip" -o terraform.zip && \
+    unzip terraform.zip && \
+    mv terraform /usr/local/bin/ && \
+    rm terraform.zip &&\
+# Install Helm
+    curl -fsSL "https://get.helm.sh/helm-v${helm_ver}-linux-amd64.tar.gz" -o helm.tar.gz && \
+    tar -zxvf helm.tar.gz && \
+    mv linux-amd64/helm /usr/local/bin/helm && \
+    rm -rf linux-amd64 helm.tar.gz &&\
+# Install Kafka client
+    curl -fsSL "https://archive.apache.org/dist/kafka/${kafka_ver}/kafka_2.13-${kafka_ver}.tgz" -o kafka_2.13-${kafka_ver}.tgz && \
+    tar -xzf kafka_2.13-${kafka_ver}.tgz && \
+    mv kafka_2.13-${kafka_ver} /opt/kafka && \
+	rm -rf kafka_2.13-${kafka_ver}.tgz &&\
+# Install Kubectl
+    curl -LO "https://dl.k8s.io/release/${kubectl_ver}/bin/linux/amd64/kubectl" && \
+    chmod +x kubectl && \
+	mv kubectl /usr/local/bin/
+
+# Set the working directory
+WORKDIR /home/jenkins
+
+
+
+
+
+

--- a/scripts/docker/jenkinsAgent/Dockerfile
+++ b/scripts/docker/jenkinsAgent/Dockerfile
@@ -18,22 +18,24 @@ RUN apk update && \
 # Install Terraform
 RUN curl -fsSL "https://releases.hashicorp.com/terraform/${terraform_ver}/terraform_${terraform_ver}_linux_amd64.zip" -o terraform.zip && \
     unzip terraform.zip && \
+    chmod +x terraform && \
     mv terraform /usr/local/bin/ && \
     rm terraform.zip &&\
 # Install Helm
     curl -fsSL "https://get.helm.sh/helm-v${helm_ver}-linux-amd64.tar.gz" -o helm.tar.gz && \
     tar -zxvf helm.tar.gz && \
+    chmod +x linux-amd64/helm && \
     mv linux-amd64/helm /usr/local/bin/helm && \
     rm -rf linux-amd64 helm.tar.gz &&\
 # Install Kafka client
     curl -fsSL "https://archive.apache.org/dist/kafka/${kafka_ver}/kafka_2.13-${kafka_ver}.tgz" -o kafka_2.13-${kafka_ver}.tgz && \
     tar -xzf kafka_2.13-${kafka_ver}.tgz && \
     mv kafka_2.13-${kafka_ver} /opt/kafka && \
-	rm -rf kafka_2.13-${kafka_ver}.tgz &&\
+	  rm -rf kafka_2.13-${kafka_ver}.tgz &&\
 # Install Kubectl
     curl -LO "https://dl.k8s.io/release/${kubectl_ver}/bin/linux/amd64/kubectl" && \
     chmod +x kubectl && \
-	mv kubectl /usr/local/bin/
+    mv kubectl /usr/local/bin/
 
 # Set the working directory
 WORKDIR /home/jenkins

--- a/scripts/docker/jenkinsAgent/Jenkinsfile
+++ b/scripts/docker/jenkinsAgent/Jenkinsfile
@@ -1,12 +1,6 @@
 #!groovy
 
 import org.folio.Constants
-import org.folio.models.FolioModule
-import org.folio.models.InstallRequestParams
-import org.folio.models.OkapiTenant
-import org.folio.models.RancherNamespace
-import org.folio.rest_v2.Main
-import org.folio.utilities.GitHubClient
 import org.folio.utilities.Logger
 
 @Library('pipelines-shared-library') _
@@ -18,6 +12,7 @@ properties([
     /**
      *  Placeholder for job parameters
      *  */
+    string(name: 'DOCKERFILE_BRANCH', defaultValue: "master", description: 'Dockerfile Branch'),
     string(name: 'IMAGE_TAG', defaultValue: "alpine-jdk17-${BUILD_NUMBER}", description: 'Agent Image Tag'),
     string(name: 'TERRAFORM_VER', defaultValue: '1.6.0', description: 'Terraform version'),
     string(name: 'HELM_VER', defaultValue: '3.15.4', description: 'Helm version'),
@@ -44,7 +39,7 @@ ansiColor('xterm') {
     try {
         stage ('[Git] Checkout source') {
           checkout scmGit(
-              branches: [[name: '*/RANCHER-1374']],
+              branches: [[name: '*/${DOCKERFILE_BRANCH}']],
               extensions: [],
               userRemoteConfigs: [[url: 'https://github.com/folio-org/pipelines-shared-library.git']])
         }
@@ -53,7 +48,12 @@ ansiColor('xterm') {
       stage('[Docker] Build and push') {
         docker.withRegistry("https://${Constants.ECR_FOLIO_REPOSITORY}", "ecr:${Constants.AWS_REGION}:${Constants.ECR_FOLIO_REPOSITORY_CREDENTIALS_ID}") {
           dir(dockerfilePath) {
-            def image = docker.build("folio-jenkins-agent:${IMAGE_TAG}", "--build-arg terraform_ver=${TERRAFORM_VER} --build-arg helm_ver=${HELM_VER} --build-arg kubectl_ver=${KUBECTL_VER} --build-arg kafka_ver=${KAFKA_VER} --no-cache=true --pull=true ." )
+            def image = docker.build("folio-jenkins-agent:${IMAGE_TAG}", "
+            --build-arg terraform_ver=${TERRAFORM_VER} \
+            --build-arg helm_ver=${HELM_VER} \
+            --build-arg kubectl_ver=${KUBECTL_VER} \
+            --build-arg kafka_ver=${KAFKA_VER} \
+            --no-cache=true --pull=true .")
             image.push()
             image.push('latest')
           }

--- a/scripts/docker/jenkinsAgent/Jenkinsfile
+++ b/scripts/docker/jenkinsAgent/Jenkinsfile
@@ -1,0 +1,72 @@
+#!groovy
+
+import org.folio.Constants
+import org.folio.models.FolioModule
+import org.folio.models.InstallRequestParams
+import org.folio.models.OkapiTenant
+import org.folio.models.RancherNamespace
+import org.folio.rest_v2.Main
+import org.folio.utilities.GitHubClient
+import org.folio.utilities.Logger
+
+@Library('pipelines-shared-library') _
+
+properties([
+  buildDiscarder(logRotator(numToKeepStr: '30')),
+  disableConcurrentBuilds(),
+  parameters([
+    /**
+     *  Placeholder for job parameters
+     *  */
+    string(name: 'IMAGE_TAG', defaultValue: "alpine-jdk17-${BUILD_NUMBER}", description: 'Agent Image Tag'),
+    string(name: 'TERRAFORM_VER', defaultValue: '1.6.0', description: 'Terraform version'),
+    string(name: 'HELM_VER', defaultValue: '3.15.4', description: 'Helm version'),
+    string(name: 'KUBECTL_VER', defaultValue: 'v1.28.0', description: 'Kubectl version'),
+    string(name: 'KAFKA_VER', defaultValue: '3.8.0', description: 'Kafka version'),
+
+    folioParameters.refreshParameters()
+  ])
+])
+
+if (params.REFRESH_PARAMETERS) {
+  currentBuild.result = 'ABORTED'
+  return
+}
+
+
+Logger logger = new Logger(this, env.JOB_BASE_NAME)
+
+def dockerfilePath = './scripts/docker/jenkinsAgent/'
+
+
+ansiColor('xterm') {
+  node('') {
+    try {
+        stage ('[Git] Checkout source') {
+          checkout scmGit(
+              branches: [[name: '*/RANCHER-1374']],
+              extensions: [],
+              userRemoteConfigs: [[url: 'https://github.com/folio-org/pipelines-shared-library.git']])
+        }
+
+
+      stage('[Docker] Build and push') {
+        docker.withRegistry("https://${Constants.ECR_FOLIO_REPOSITORY}", "ecr:${Constants.AWS_REGION}:${Constants.ECR_FOLIO_REPOSITORY_CREDENTIALS_ID}") {
+          dir(dockerfilePath) {
+            def image = docker.build("folio-jenkins-agent:${IMAGE_TAG}", "--build-arg terraform_ver=${TERRAFORM_VER} --build-arg helm_ver=${HELM_VER} --build-arg kubectl_ver=${KUBECTL_VER} --build-arg kafka_ver=${KAFKA_VER} --no-cache=true --pull=true ." )
+            image.push()
+            image.push('latest')
+          }
+        }
+      }
+    } catch (e) {
+      logger.error("Caught exception: ${e}")
+      error(e.getMessage())
+    } finally {
+      stage('Cleanup') {
+        logger.warning("Workspace size: ${sh(returnStdout: true, script: 'du -sh .').trim()}")
+        cleanWs notFailBuild: true
+      }
+    }
+  }
+}


### PR DESCRIPTION
Create a tiny base Jenkins agent docker image with tools required for common operations on Jenkins, it should include:

AWS CLI
Terraform client
Helm client
Psql and pg_dump client
Kafka client
Kubectl
Curl
Git
Java (version according to required by Jenkins for remote.jar)

Create a repository in ECR to store this Jenkins agent base image
Create a pipeline to automate build and publish operation for future upgrades