### PR TITLE
RANCHER-1792 Restrict access jobs for sprint-testing environment

### DIFF
--- a/pipelines/Jenkinsfile.template
+++ b/pipelines/Jenkinsfile.template
@@ -27,6 +27,10 @@ if (params.REFRESH_PARAMETERS) {
   return
 }
 
+if (params.CLUSTER == 'folio-testing') {
+  folioCommon.kitfoxApproval()
+}
+
 /**
  * Job variables
  */

--- a/pipelines/folioRancher/folioDevTools/moduleDeployment/deployModuleFromFeatureBranch/Jenkinsfile
+++ b/pipelines/folioRancher/folioDevTools/moduleDeployment/deployModuleFromFeatureBranch/Jenkinsfile
@@ -35,6 +35,10 @@ if (params.REFRESH_PARAMETERS) {
   return
 }
 
+if (params.CLUSTER == 'folio-testing') {
+  folioCommon.kitfoxApproval()
+}
+
 Logger logger = new Logger(this, env.JOB_BASE_NAME)
 
 FolioModule module = new FolioModule()

--- a/pipelines/folioRancher/folioDevTools/moduleDeployment/deployModulesFromJson/Jenkinsfile
+++ b/pipelines/folioRancher/folioDevTools/moduleDeployment/deployModulesFromJson/Jenkinsfile
@@ -41,6 +41,10 @@ if (params.REFRESH_PARAMETERS) {
   return
 }
 
+if (params.CLUSTER == 'folio-testing') {
+  folioCommon.kitfoxApproval()
+}
+
 // Validate inputs
 validateInputs(params)
 

--- a/pipelines/folioRancher/folioDevTools/moduleDeployment/installModulesFromJson/Jenkinsfile
+++ b/pipelines/folioRancher/folioDevTools/moduleDeployment/installModulesFromJson/Jenkinsfile
@@ -41,6 +41,10 @@ if (params.REFRESH_PARAMETERS) {
   return
 }
 
+if (params.CLUSTER == 'folio-testing') {
+  folioCommon.kitfoxApproval()
+}
+
 /**
  * Validate inputs
  */

--- a/pipelines/folioRancher/folioDevTools/uiManagement/deployUI/Jenkinsfile
+++ b/pipelines/folioRancher/folioDevTools/uiManagement/deployUI/Jenkinsfile
@@ -29,6 +29,16 @@ properties([
     folioParameters.refreshParameters(),
   ])
 ])
+
+if (params.REFRESH_PARAMETERS) {
+  currentBuild.result = 'ABORTED'
+  return
+}
+
+if (params.CLUSTER == 'folio-testing') {
+  folioCommon.kitfoxApproval()
+}
+
 String defaultTenantId = 'diku'
 
 //Set namespace configuration
@@ -64,10 +74,6 @@ if (params.CONSORTIA) {
     }
     namespace.addTenant(tenant)
   }
-}
-if (params.REFRESH_PARAMETERS) {
-  currentBuild.result = 'ABORTED'
-  return
 }
 
 ansiColor('xterm') {

--- a/pipelines/folioRancher/folioNamespaceTools/manageNamespace/createNamespace/Jenkinsfile
+++ b/pipelines/folioRancher/folioNamespaceTools/manageNamespace/createNamespace/Jenkinsfile
@@ -28,6 +28,10 @@ if (params.REFRESH_PARAMETERS) {
   return
 }
 
+if (params.CLUSTER == 'folio-testing') {
+  folioCommon.kitfoxApproval()
+}
+
 CreateNamespaceParameters namespaceParams = new CreateNamespaceParameters.Builder()
   .clusterName(params.CLUSTER)
   .namespaceName(params.NAMESPACE)

--- a/pipelines/folioRancher/folioNamespaceTools/manageNamespace/createNamespaceFromBranch/Jenkinsfile
+++ b/pipelines/folioRancher/folioNamespaceTools/manageNamespace/createNamespaceFromBranch/Jenkinsfile
@@ -35,6 +35,10 @@ if (params.REFRESH_PARAMETERS) {
   return
 }
 
+if (params.CLUSTER == 'folio-testing') {
+  folioCommon.kitfoxApproval()
+}
+
 CreateNamespaceParameters namespaceParams = new CreateNamespaceParameters.Builder()
   .clusterName(params.CLUSTER)
   .namespaceName(params.NAMESPACE)

--- a/pipelines/folioRancher/folioNamespaceTools/manageNamespace/createNamespaceFromRdsSnapshot/Jenkinsfile
+++ b/pipelines/folioRancher/folioNamespaceTools/manageNamespace/createNamespaceFromRdsSnapshot/Jenkinsfile
@@ -32,6 +32,10 @@ if (params.REFRESH_PARAMETERS) {
   return
 }
 
+if (params.CLUSTER == 'folio-testing') {
+  folioCommon.kitfoxApproval()
+}
+
 /**
  * Set terraform configuration
  */

--- a/pipelines/folioRancher/folioNamespaceTools/manageNamespace/deleteNamespace/Jenkinsfile
+++ b/pipelines/folioRancher/folioNamespaceTools/manageNamespace/deleteNamespace/Jenkinsfile
@@ -24,6 +24,10 @@ if (params.REFRESH_PARAMETERS) {
   return
 }
 
+if (params.CLUSTER == 'folio-testing') {
+  folioCommon.kitfoxApproval()
+}
+
 boolean nsExists
 
 CreateNamespaceParameters namespaceParams = new CreateNamespaceParameters.Builder()

--- a/src/org/folio/Constants.groovy
+++ b/src/org/folio/Constants.groovy
@@ -103,7 +103,7 @@ class Constants {
   static String ECS_EDGE_GENERAL_PASSWORD = 'edge'
 
   //Eureka base constants
-  static  String EUREKA_REGISTRY_URL = 'https://eureka-registry.ci.folio.org/descriptors/'
+  static String EUREKA_REGISTRY_URL = 'https://eureka-registry.ci.folio.org/descriptors/'
 
   //SMTP
   static String EMAIL_SMTP_CREDENTIALS_ID = 'ses-smtp-rancher'
@@ -135,6 +135,7 @@ class Constants {
   static String DOCKER_K8S_CLIENT_IMAGE = 'alpine/k8s:1.22.15'
 
   //Jenkins
+  static List JENKINS_KITFOX_USER_IDS = ['ohaimanov', 'eldiiar-duishenaliev', 'dmytrmoroz', 'aatoyan', 'epam-avramenko', 'yaroslavishchenko', 'sergii-msn']
   static String JENKINS_MASTER_NODE = 'master'
   static String JENKINS_JOB_PROJECT = '/Rancher/Project'
   static String JENKINS_JOB_RESTORE_PG_BACKUP = 'Rancher/Create-Restore-PosgreSQL-DB-backup'

--- a/vars/folioCommon.groovy
+++ b/vars/folioCommon.groovy
@@ -1,3 +1,5 @@
+import org.folio.Constants
+
 void defaultJobWrapper(Closure stages, boolean checkoutGit = true) {
   try {
     if (checkoutGit) {
@@ -16,4 +18,36 @@ void defaultJobWrapper(Closure stages, boolean checkoutGit = true) {
       cleanWs notFailBuild: true
     }
   }
+}
+
+void kitfoxApproval() {
+  // Retrieve the cause related to a specific user
+  Map userCause = getUserCause()
+
+  // Check if the user ID is in the allowed list
+  if (isApprovedUser(userCause?.userId)) {
+    return
+  }
+
+  // Trigger a manual input approval for non-approved users
+  requestApproval()
+}
+
+// Method to retrieve the user cause
+private Map getUserCause() {
+  return currentBuild.getBuildCauses().find { it._class == 'hudson.model.Cause$UserIdCause' }
+}
+
+// Method to check if the user ID is in the approved list
+private boolean isApprovedUser(String userId) {
+  return Constants.JENKINS_KITFOX_USER_IDS.contains(userId)
+}
+
+// Method to trigger an approval input prompt
+private void requestApproval() {
+  input(
+    message: 'Attention! This action must be approved by the Kitfox team. Please contact #rancher-support on Slack.',
+    ok: 'Proceed',
+    submitter: Constants.JENKINS_KITFOX_USER_IDS.join(', ')
+  )
 }


### PR DESCRIPTION
Jira: https://folio-org.atlassian.net/browse/RANCHER-1792

As a result, in particular jobs that can affect folio-testing environments was added logic to request approve if job triggered by not Kitfox team member
<img width="797" alt="image" src="https://github.com/user-attachments/assets/742b82dc-b3ab-4926-83b7-32424f956e94">
