### PR TITLE
RANCHER-1795: Support Thunderjet with redeploying mod-consortia-keycloak from branch for UAT testing

### DIFF
--- a/pipelines/folioRancher/folioDevTools/moduleDeployment/deployModuleFromFeatureBranchEureka/Jenkinsfile
+++ b/pipelines/folioRancher/folioDevTools/moduleDeployment/deployModuleFromFeatureBranchEureka/Jenkinsfile
@@ -191,12 +191,6 @@ ansiColor('xterm') {
       stage('Generate context') {
         namespace.tenants = eureka.getExistedTenants(module.name)
 
-        switch (module.name) {
-          case 'mod-consortia-keycloak':
-            // Remove default (not ECS) tenant from the list in case of consortia module
-            namespace.tenants.remove(namespace.defaultTenantId)
-        }
-
         logger.info("Configured Tenants: ${namespace.tenants}")
 
         namespace.withApplications(eureka.getEnabledApplications(namespace.tenants))

--- a/pipelines/folioRancher/folioDevTools/moduleDeployment/deployModuleFromFeatureBranchEureka/Jenkinsfile
+++ b/pipelines/folioRancher/folioDevTools/moduleDeployment/deployModuleFromFeatureBranchEureka/Jenkinsfile
@@ -187,7 +187,7 @@ ansiColor('xterm') {
       }
 
       stage('Generate context') {
-        namespace.tenants = eureka.getExistedTenants()
+        namespace.tenants = eureka.getExistedTenants(module.name)
 
         switch (module.name) {
           case 'mod-consortia-keycloak':

--- a/pipelines/folioRancher/folioDevTools/moduleDeployment/deployModuleFromFeatureBranchEureka/Jenkinsfile
+++ b/pipelines/folioRancher/folioDevTools/moduleDeployment/deployModuleFromFeatureBranchEureka/Jenkinsfile
@@ -188,9 +188,13 @@ ansiColor('xterm') {
 
       stage('Generate context') {
         namespace.tenants = eureka.getExistedTenants()
-        if (module.name == 'mod-consortia-keycloak') {
-          namespace.tenants.remove(namespace.defaultTenantId)
+
+        switch (module.name) {
+          case 'mod-consortia-keycloak':
+            // Remove default (not ECS) tenant from the list in case of consortia module
+            namespace.tenants.remove(namespace.defaultTenantId)
         }
+
         logger.info("Configured Tenants: ${namespace.tenants}")
 
         namespace.withApplications(eureka.getEnabledApplications(namespace.tenants))

--- a/pipelines/folioRancher/folioDevTools/moduleDeployment/deployModuleFromFeatureBranchEureka/Jenkinsfile
+++ b/pipelines/folioRancher/folioDevTools/moduleDeployment/deployModuleFromFeatureBranchEureka/Jenkinsfile
@@ -86,6 +86,7 @@ ansiColor('xterm') {
       }
 
       stage('[Maven/Gradle] Compile') {
+        return
         // Check if Maven or Gradle build tool is used
         module.buildTool = fileExists("${module.name}/pom.xml") ? 'maven' : 'gradle'
 
@@ -138,6 +139,7 @@ ansiColor('xterm') {
       }
 
       stage('[Docker] Build and push') {
+        return
         // Put Docker Image to Amazon ECR
         docker.withRegistry("https://${Constants.ECR_FOLIO_REPOSITORY}", "ecr:${Constants.AWS_REGION}:${Constants.ECR_FOLIO_REPOSITORY_CREDENTIALS_ID}") {
           // Check if ECR Repository exists, if not create it
@@ -206,6 +208,7 @@ ansiColor('xterm') {
 
       // 1. Register Application Descriptor with Updated Module Version
       stage('[Rest] Update App Descriptor') {
+        return
         try {
           updatedAppInfoMap = eureka.updateAppDescriptorFlow(namespace.applications, namespace.getModules(), module)
         } catch (e) {
@@ -217,6 +220,7 @@ ansiColor('xterm') {
 
       // 2. Enable New Module Version (Discovery) for Application
       stage('[Rest] Module Discovery') {
+        return
         try {
           eureka.runModuleDiscoveryFlow(module)
         } catch (e) {
@@ -228,6 +232,7 @@ ansiColor('xterm') {
 
       // 3. Deploy New Module Version to Rancher Namespace via Helm
       stage('[Helm] Deploy Module Ver') {
+        return
         try {
           folioHelm.withKubeConfig(namespace.clusterName) {
             folioHelm.deployFolioModule(namespace, module.name, module.version, false, namespace.defaultTenantId)
@@ -244,6 +249,7 @@ ansiColor('xterm') {
 
       // 4. Enable Application Descriptor with Updated Module Version for Tenants in Namespace
       stage('[Rest] Enable New App') {
+        return
         try {
           eureka.enableApplicationsOnTenantsFlow(namespace.tenants, updatedAppInfoMap)
         } catch (e) {
@@ -254,6 +260,7 @@ ansiColor('xterm') {
       }
 
       stage('[Rest] Remove Stale Resources') {
+        return
         eureka.removeStaleResourcesFlow(namespace.applications, updatedAppInfoMap, module)
       }
 

--- a/pipelines/folioRancher/folioDevTools/moduleDeployment/deployModuleFromFeatureBranchEureka/Jenkinsfile
+++ b/pipelines/folioRancher/folioDevTools/moduleDeployment/deployModuleFromFeatureBranchEureka/Jenkinsfile
@@ -86,7 +86,6 @@ ansiColor('xterm') {
       }
 
       stage('[Maven/Gradle] Compile') {
-        return
         // Check if Maven or Gradle build tool is used
         module.buildTool = fileExists("${module.name}/pom.xml") ? 'maven' : 'gradle'
 
@@ -139,7 +138,6 @@ ansiColor('xterm') {
       }
 
       stage('[Docker] Build and push') {
-        return
         // Put Docker Image to Amazon ECR
         docker.withRegistry("https://${Constants.ECR_FOLIO_REPOSITORY}", "ecr:${Constants.AWS_REGION}:${Constants.ECR_FOLIO_REPOSITORY_CREDENTIALS_ID}") {
           // Check if ECR Repository exists, if not create it
@@ -202,7 +200,6 @@ ansiColor('xterm') {
 
       // 1. Register Application Descriptor with Updated Module Version
       stage('[Rest] Update App Descriptor') {
-        return
         try {
           updatedAppInfoMap = eureka.updateAppDescriptorFlow(namespace.applications, namespace.getModules(), module)
         } catch (e) {
@@ -214,7 +211,6 @@ ansiColor('xterm') {
 
       // 2. Enable New Module Version (Discovery) for Application
       stage('[Rest] Module Discovery') {
-        return
         try {
           eureka.runModuleDiscoveryFlow(module)
         } catch (e) {
@@ -226,7 +222,6 @@ ansiColor('xterm') {
 
       // 3. Deploy New Module Version to Rancher Namespace via Helm
       stage('[Helm] Deploy Module Ver') {
-        return
         try {
           folioHelm.withKubeConfig(namespace.clusterName) {
             folioHelm.deployFolioModule(namespace, module.name, module.version, false, namespace.defaultTenantId)
@@ -243,7 +238,6 @@ ansiColor('xterm') {
 
       // 4. Enable Application Descriptor with Updated Module Version for Tenants in Namespace
       stage('[Rest] Enable New App') {
-        return
         try {
           eureka.enableApplicationsOnTenantsFlow(namespace.tenants, updatedAppInfoMap)
         } catch (e) {
@@ -254,7 +248,6 @@ ansiColor('xterm') {
       }
 
       stage('[Rest] Remove Stale Resources') {
-        return
         eureka.removeStaleResourcesFlow(namespace.applications, updatedAppInfoMap, module)
       }
 

--- a/pipelines/folioRancher/folioDevTools/moduleDeployment/deployModuleFromFeatureBranchEureka/Jenkinsfile
+++ b/pipelines/folioRancher/folioDevTools/moduleDeployment/deployModuleFromFeatureBranchEureka/Jenkinsfile
@@ -9,7 +9,7 @@ import org.folio.models.FolioModule
 import org.folio.rest_v2.eureka.Eureka
 
 // TODO: RANCHER-1700 - get rid off custom branch mention once feature development is done
-@Library('pipelines-shared-library@RANCHER-1795') _
+@Library('pipelines-shared-library@RANCHER-1359-test') _
 
 /** Job properties and parameters */
 properties([

--- a/pipelines/folioRancher/folioDevTools/moduleDeployment/deployModuleFromFeatureBranchEureka/Jenkinsfile
+++ b/pipelines/folioRancher/folioDevTools/moduleDeployment/deployModuleFromFeatureBranchEureka/Jenkinsfile
@@ -9,7 +9,7 @@ import org.folio.models.FolioModule
 import org.folio.rest_v2.eureka.Eureka
 
 // TODO: RANCHER-1700 - get rid off custom branch mention once feature development is done
-@Library('pipelines-shared-library@RANCHER-1779') _
+@Library('pipelines-shared-library@RANCHER-1795') _
 
 /** Job properties and parameters */
 properties([

--- a/resources/helm/development.yaml
+++ b/resources/helm/development.yaml
@@ -1724,3 +1724,30 @@ ui-bundle:
       memory: 96Mi
     requests:
       memory: 64Mi
+mod-consortia-keycloak:
+  extraEnvVars:
+    - name: CUSTOM_FIELDS_RETRY_BACKOFF_DELAY
+      value: '5000'
+    - name: CUSTOM_FIELDS_RETRY_MAX_RETRIES
+      value: '5'
+    - name: SERVER_PORT
+      value: '8080'
+  integrations:
+    db:
+      enabled: true
+      existingSecret: db-credentials
+    kafka:
+      enabled: true
+      existingSecret: kafka-credentials
+    okapi:
+      enabled: true
+      existingSecret: okapi-credentials
+    systemuser:
+      enabled: true
+      existingSecret: mod-consortia-keycloak-systemuser
+  replicaCount: 1
+  resources:
+    limits:
+      memory: 1Gi
+    requests:
+      memory: 256Mi

--- a/src/org/folio/rest_v2/eureka/Eureka.groovy
+++ b/src/org/folio/rest_v2/eureka/Eureka.groovy
@@ -246,8 +246,14 @@ class Eureka extends Base {
         }
       }
 
-      // Assign enabled applications to Tenant object
-      tenant.applications = enabledAppsMap.clone() as Map
+      if (enabledAppsMap.isEmpty()) {
+        // Remove tenant without requested module from the configured tenants map
+        configuredTenantsMap.remove(tenantName)
+      }
+      else {
+        // Assign enabled applications to Tenant object
+        tenant.applications = enabledAppsMap.clone() as Map
+      }
     }
 
     return configuredTenantsMap

--- a/src/org/folio/rest_v2/eureka/Eureka.groovy
+++ b/src/org/folio/rest_v2/eureka/Eureka.groovy
@@ -239,8 +239,14 @@ class Eureka extends Base {
 
       // Get enabled applications from the Environment
       Tenants.get(kong).getEnabledApplications(tenant, "", true).each { appId, entitlement ->
+        // Check if the module is enabled for the tenant
         if (entitlement.modules.find { moduleId -> moduleId.startsWith(moduleName) }) {
+          // Save enabled application with the module to Map for processing
           enabledAppsMap.put(appId.split("-\\d+\\.\\d+\\.\\d+")[0], appId)
+        }
+        else {
+          // Exclude tenant that doesn't have the module enabled
+          configuredTenantsMap.remove(tenantName)
         }
       }
 

--- a/src/org/folio/rest_v2/eureka/Eureka.groovy
+++ b/src/org/folio/rest_v2/eureka/Eureka.groovy
@@ -244,10 +244,6 @@ class Eureka extends Base {
           // Save enabled application with the module to Map for processing
           enabledAppsMap.put(appId.split("-\\d+\\.\\d+\\.\\d+")[0], appId)
         }
-        else {
-          // Exclude tenant that doesn't have the module enabled
-          configuredTenantsMap.remove(tenantName)
-        }
       }
 
       // Assign enabled applications to Tenant object

--- a/src/org/folio/rest_v2/eureka/Eureka.groovy
+++ b/src/org/folio/rest_v2/eureka/Eureka.groovy
@@ -222,9 +222,10 @@ class Eureka extends Base {
 
   /**
    * Get Configured Tenants on Environment Namespace.
+   * @param moduleName Module Name to filter enabled applications.
    * @return Map of EurekaTenant objects.
    */
-  Map<String, EurekaTenant> getExistedTenants() {
+  Map<String, EurekaTenant> getExistedTenants(String moduleName) {
     /** Configured Tenants in Environment (namespace) */
     Map<String, EurekaTenant> configuredTenantsMap
 
@@ -237,8 +238,10 @@ class Eureka extends Base {
       Map<String, String> enabledAppsMap = [:]
 
       // Get enabled applications from the Environment
-      Tenants.get(kong).getEnabledApplications(tenant).each { appId, app ->
-        enabledAppsMap.put(appId.split("-\\d+\\.\\d+\\.\\d+")[0], appId)
+      Tenants.get(kong).getEnabledApplications(tenant, "", true).each { appId, entitlement ->
+        if (entitlement.modules.find { moduleId -> moduleId.startsWith(moduleName) }) {
+          enabledAppsMap.put(appId.split("-\\d+\\.\\d+\\.\\d+")[0], appId)
+        }
       }
 
       // Assign enabled applications to Tenant object
@@ -256,7 +259,7 @@ class Eureka extends Base {
     /** Enabled Applications in Environment */
     Map <String, String> enabledAppsMap = [:]
 
-    // Get enabled applications from EurekaTenant List of objects
+    // Get enabled applications from EurekaTenant List
     tenants.values().each {tenant ->
       tenant.applications.each {appName, appId ->
         enabledAppsMap.put(appName, appId)


### PR DESCRIPTION
[RANCHER-1795: Support Thunderjet with redeploying mod-consortia-keycloak from branch for UAT testing ](https://folio-org.atlassian.net/browse/RANCHER-1795)

Jenkins Pipeline for verification:
https://jenkins-aws.indexdata.com/job/folioRancher/job/tmpFolderForDraftPipelines/job/Eureka/job/deployModuleFromFeatureBranchEureka/