### PR TITLE
RANCHER-1770 ReWorked & GENERALIZED "ephemeralProperties" files generation

### DIFF
--- a/pipelines/folioRancher/folioNamespaceTools/manageNamespace/createNamespaceFromBranch/Jenkinsfile
+++ b/pipelines/folioRancher/folioNamespaceTools/manageNamespace/createNamespaceFromBranch/Jenkinsfile
@@ -4,7 +4,7 @@ import org.jenkinsci.plugins.workflow.libs.Library
 import org.folio.models.parameters.CreateNamespaceParameters
 
 //TODO remove branch before merge to master
-@Library('pipelines-shared-library@RANCHER-1359-test') _ // testing part | start
+@Library('pipelines-shared-library@RANCHER-1359-test') _
 
 //TODO add selector OKAPI/EUREKA instead EUREKA boolean flag
 properties([

--- a/pipelines/folioRancher/folioNamespaceTools/manageNamespace/createNamespaceFromBranch/Jenkinsfile
+++ b/pipelines/folioRancher/folioNamespaceTools/manageNamespace/createNamespaceFromBranch/Jenkinsfile
@@ -4,7 +4,7 @@ import org.jenkinsci.plugins.workflow.libs.Library
 import org.folio.models.parameters.CreateNamespaceParameters
 
 //TODO remove branch before merge to master
-@Library('pipelines-shared-library@RANCHER-1770') _ // testing part | start
+@Library('pipelines-shared-library@RANCHER-1359-test') _ // testing part | start
 
 //TODO add selector OKAPI/EUREKA instead EUREKA boolean flag
 properties([

--- a/pipelines/folioRancher/folioNamespaceTools/manageNamespace/createNamespaceFromBranch/Jenkinsfile
+++ b/pipelines/folioRancher/folioNamespaceTools/manageNamespace/createNamespaceFromBranch/Jenkinsfile
@@ -4,7 +4,7 @@ import org.jenkinsci.plugins.workflow.libs.Library
 import org.folio.models.parameters.CreateNamespaceParameters
 
 //TODO remove branch before merge to master
-@Library('pipelines-shared-library@RANCHER-1359-test') _
+@Library('pipelines-shared-library@RANCHER-1770') _ // testing part | start
 
 //TODO add selector OKAPI/EUREKA instead EUREKA boolean flag
 properties([

--- a/resources/edge/config_eureka.yaml
+++ b/resources/edge/config_eureka.yaml
@@ -1,3 +1,24 @@
+edge-users:
+  tenants:
+    - tenant: default
+      username: edgeUser
+      firstName: edge
+      lastName: SYSTEM
+      password: edgeUser123!
+      create: true
+  capabilities:
+    - users_collection.view
+    - users_item.create
+edge-inventory:
+  tenants:
+    - tenant: default
+      username: edgeInventory
+      firstName: edge
+      lastName: SYSTEM
+      password: edgeInventory123!
+      create: true
+  capabilities:
+    - inventory_instances_item.view
 edge-rtac:
   capabilitiesSet:
   - rtac.manage

--- a/src/org/folio/utilities/Tools.groovy
+++ b/src/org/folio/utilities/Tools.groovy
@@ -60,7 +60,7 @@ class Tools {
    */
   @NonCPS
   static def jsonParse(String json) {
-    new JsonSlurperClassic().parseText(json)
+    return new JsonSlurperClassic().parseText(json)
   }
 
   /**

--- a/vars/folioEdge.groovy
+++ b/vars/folioEdge.groovy
@@ -1,3 +1,4 @@
+import groovy.json.JsonSlurperClassic
 import groovy.text.StreamingTemplateEngine
 import org.folio.Constants
 import org.folio.models.RancherNamespace
@@ -74,9 +75,9 @@ void renderEphemeralPropertiesEureka(RancherNamespace namespace) {
 
   common.logger.info("Response: " + json)
 
-  def dataToProcess = tools.jsonParse(json as String)
+  def dataToProcess = new JsonSlurperClassic().parseText(json as String)
 
-  common.logger.info("List of existing tenants: ${dataToProcess['tenants'][0]['name']}")
+  common.logger.info("List of existing tenants: ${dataToProcess['tenants']['name']}")
 
   if ('fs09000000' in dataToProcess.tenants.name) { // to the mappings part
     mappings.add('fs09000000')

--- a/vars/folioEdge.groovy
+++ b/vars/folioEdge.groovy
@@ -101,6 +101,8 @@ void renderEphemeralPropertiesEureka(RancherNamespace namespace) {
           tenants.each { tenantName ->
             institutionalUsers += "${tenantName}=${institutional.username},${institutional.password}\n"
           }
+        } else {
+          institutionalUsers += "${institutional.tenant}=${institutional.username},${institutional.password}\n"
         }
       }
       LinkedHashMap config_data = [edge_tenants: "${tenants.join(",")}", edge_mappings: "${mappings.getAt(0)}", edge_users: users + institutionalUsers, institutional_users: '']

--- a/vars/folioEdge.groovy
+++ b/vars/folioEdge.groovy
@@ -97,9 +97,9 @@ void renderEphemeralPropertiesEureka(RancherNamespace namespace) {
     if (edgeConfig[(name)]['tenants']) {
       edgeConfig[(name)]['tenants'].each { institutional ->
         institutional.tenant == 'default' ? '' : tenants.add(institutional.tenant)
-        institutionalUsers += "${(institutional.tenant == 'default' ? mappings.getAt(0) : institutional.tenant)}=${institutional.username},${institutional.password}\n"
+        institutionalUsers += "${(institutional.tenant == 'default' ? mappings.getAt(0) : institutional.tenant)}=${institutional.username},${institutional.password}"
       }
-      LinkedHashMap config_data = [edge_tenants: "${tenants.join(",")}", edge_mappings: "${mappings.getAt(0)}", edge_users: users, institutional_users: institutionalUsers]
+      LinkedHashMap config_data = [edge_tenants: "${tenants.join(",")}", edge_mappings: "${mappings.getAt(0)}", edge_users: users + institutionalUsers, institutional_users: 'fake=tenant,info']
       tools.steps.writeFile file: "${name}-ephemeral-properties", text: (new StreamingTemplateEngine().createTemplate(config_template).make(config_data)).toString()
       common.logger.info("ephemeralProperties file for module ${name} created.")
     }

--- a/vars/folioEdge.groovy
+++ b/vars/folioEdge.groovy
@@ -68,11 +68,10 @@ void renderEphemeralPropertiesEureka(RancherNamespace namespace) {
   String config_template = tools.steps.readFile file: tools.copyResourceFileToCurrentDirectory("edge/ephemeral-properties.tpl")
   List mappings = []
   String users = ''
-  RestClient client = new RestClient(this)
 
-  def json = client.get("https://${namespace.generateDomain('kong')}/tenants").body
+  def json = tools.steps.sh(script: "set +e && https://${namespace.generateDomain('kong')}/tenants", returnStdOut: true)
 
-  common.logger.info("Response: " + json)
+  common.logger.info("Response: ${json}")
 
   def dataToProcess = tools.jsonParse(json as String)
 

--- a/vars/folioEdge.groovy
+++ b/vars/folioEdge.groovy
@@ -85,7 +85,7 @@ void renderEphemeralPropertiesEureka(RancherNamespace namespace) {
   def tenants = dataToProcess['tenants']['name']
 
   dataToProcess['tenants'].each { candidate -> // real existing tenant's metadata include
-    users += folioDefault.tenants()["${candidate['name']}"].tenantId + '=' + folioDefault.tenants()["${candidate['name']}"].getAdminUser() + ','
+    users += folioDefault.tenants()["${candidate['name']}"].tenantId + '=' + folioDefault.tenants()["${candidate['name']}"].getAdminUser().username + ','
     +folioDefault.tenants()["${candidate['name']}"].getAdminUser().passwordPlainText + '\n'
   }
 

--- a/vars/folioEdge.groovy
+++ b/vars/folioEdge.groovy
@@ -69,7 +69,7 @@ void renderEphemeralPropertiesEureka(RancherNamespace namespace) {
   List mappings = []
   String users = ''
 
-  def json = tools.steps.sh(script: "curl --silent https://${namespace.generateDomain('kong')}/tenants")
+  def json = tools.steps.sh(script: "curl --silent https://${namespace.generateDomain('kong')}/tenants", returnStdout: true)
 
   common.logger.info("Response: ${json}")
 

--- a/vars/folioEdge.groovy
+++ b/vars/folioEdge.groovy
@@ -74,11 +74,11 @@ void renderEphemeralPropertiesEureka(RancherNamespace namespace) {
 
   common.logger.info("Response: " + json)
 
-  def dataToProcess = new JsonSlurperClassic().parseText(json)
+  def dataToProcess = tools.jsonParse(json)
 
   common.logger.info("List of existing tenants: ${dataToProcess['tenants']['name']}")
 
-  if ('fs09000000' in dataToProcess.tenants.name) { // to the mappings part
+  if ('fs09000000' in dataToProcess['tenants']['name']) { // to the mappings part
     mappings.add('fs09000000')
   } else {
     mappings.add('diku')

--- a/vars/folioEdge.groovy
+++ b/vars/folioEdge.groovy
@@ -74,7 +74,7 @@ void renderEphemeralPropertiesEureka(RancherNamespace namespace) {
 
   common.logger.info("Response: " + json)
 
-  def dataToProcess = tools.jsonParse(json)
+  def dataToProcess = tools.jsonParse(json as String)
 
   common.logger.info("List of existing tenants: ${dataToProcess['tenants']['name']}")
 

--- a/vars/folioEdge.groovy
+++ b/vars/folioEdge.groovy
@@ -1,4 +1,3 @@
-import groovy.json.JsonOutput
 import groovy.json.JsonSlurperClassic
 import groovy.text.StreamingTemplateEngine
 import org.folio.Constants
@@ -6,7 +5,6 @@ import org.folio.models.RancherNamespace
 import org.folio.rest_v2.Common
 import org.folio.utilities.RestClient
 import org.folio.utilities.Tools
-
 /**
  * Renders the ephemeral properties for a tenant.
  *
@@ -76,7 +74,7 @@ void renderEphemeralPropertiesEureka(RancherNamespace namespace) {
 
   common.logger.info("Response: " + json)
 
-  def dataToProcess = new JsonOutput().toJson(json)
+  def dataToProcess = new JsonSlurperClassic().parseText(json)
 
   common.logger.info("List of existing tenants: ${dataToProcess['tenants']['name']}")
 

--- a/vars/folioEdge.groovy
+++ b/vars/folioEdge.groovy
@@ -82,9 +82,9 @@ void renderEphemeralPropertiesEureka(RancherNamespace namespace) {
   } else {
     mappings.add('diku')
   }
-  def tenants = dataToProcess['tenants']
+  def tenants = dataToProcess['tenants']['name']
 
-  dataToProcess.each { candidate -> // real existing tenant's metadata include
+  dataToProcess['tenants'].each { candidate -> // real existing tenant's metadata include
     users += folioDefault.tenants()["${candidate['name']}"].tenantId + '=' + folioDefault.tenants()["${candidate['name']}"].getAdminUser() + ','
     +folioDefault.tenants()["${candidate['name']}"].getAdminUser().passwordPlainText + '\n'
   }

--- a/vars/folioEdge.groovy
+++ b/vars/folioEdge.groovy
@@ -102,9 +102,9 @@ void renderEphemeralPropertiesEureka(RancherNamespace namespace) {
         institutional.tenant == 'default' ? '' : tenants.add(institutional.tenant)
         institutionalUsers += "${(institutional.tenant == 'default' ? mappings.getAt(0) : institutional.tenant)}=${institutional.username},${institutional.password}\n"
       }
+      LinkedHashMap config_data = [edge_tenants: "${tenants.join(",")}", edge_mappings: "${mappings.getAt(0)}", edge_users: users, institutional_users: institutionalUsers]
+      tools.steps.writeFile file: "${name}-ephemeral-properties", text: (new StreamingTemplateEngine().createTemplate(config_template).make(config_data)).toString()
+      common.logger.info("ephemeralProperties file for module ${name} created.")
     }
-    LinkedHashMap config_data = [edge_tenants: "${tenants.join(",")}", edge_mappings: "${mappings.getAt(0)}", edge_users: users, institutional_users: institutionalUsers]
-    tools.steps.writeFile file: "${name}-ephemeral-properties", text: (new StreamingTemplateEngine().createTemplate(config_template).make(config_data)).toString()
-    common.logger.info("ephemeralProperties file for module ${name} created.")
   }
 }

--- a/vars/folioEdge.groovy
+++ b/vars/folioEdge.groovy
@@ -69,7 +69,7 @@ void renderEphemeralPropertiesEureka(RancherNamespace namespace) {
   List mappings = []
   String users = ''
 
-  def json = tools.steps.sh(script: "set +e && curl https://${namespace.generateDomain('kong')}/tenants", returnStdOut: true)
+  def json = tools.steps.sh(script: "curl --silent https://${namespace.generateDomain('kong')}/tenants")
 
   common.logger.info("Response: ${json}")
 

--- a/vars/folioEdge.groovy
+++ b/vars/folioEdge.groovy
@@ -96,10 +96,14 @@ void renderEphemeralPropertiesEureka(RancherNamespace namespace) {
     String institutionalUsers = ''
     if (edgeConfig[(name)]['tenants']) {
       edgeConfig[(name)]['tenants'].each { institutional ->
-        institutional.tenant == 'default' ? '' : tenants.add(institutional.tenant)
-        institutionalUsers += "${(institutional.tenant == 'default' ? mappings.getAt(0) : institutional.tenant)}=${institutional.username},${institutional.password}"
+        if (institutional.tenant == 'default') {
+          tenants.add(institutional.tenant)
+          tenants.each { tenantName ->
+            institutionalUsers += "${tenantName}=${institutional.username},${institutional.password}\n"
+          }
+        }
       }
-      LinkedHashMap config_data = [edge_tenants: "${tenants.join(",")}", edge_mappings: "${mappings.getAt(0)}", edge_users: users + institutionalUsers, institutional_users: 'fake=tenant,info']
+      LinkedHashMap config_data = [edge_tenants: "${tenants.join(",")}", edge_mappings: "${mappings.getAt(0)}", edge_users: users + institutionalUsers, institutional_users: '']
       tools.steps.writeFile file: "${name}-ephemeral-properties", text: (new StreamingTemplateEngine().createTemplate(config_template).make(config_data)).toString()
       common.logger.info("ephemeralProperties file for module ${name} created.")
     }

--- a/vars/folioEdge.groovy
+++ b/vars/folioEdge.groovy
@@ -1,3 +1,4 @@
+import groovy.json.JsonOutput
 import groovy.json.JsonSlurperClassic
 import groovy.text.StreamingTemplateEngine
 import org.folio.Constants
@@ -75,7 +76,7 @@ void renderEphemeralPropertiesEureka(RancherNamespace namespace) {
 
   common.logger.info("Response: " + json)
 
-  def dataToProcess = new JsonSlurperClassic().parseText(json as String)
+  def dataToProcess = new JsonOutput().toJson(json)
 
   common.logger.info("List of existing tenants: ${dataToProcess['tenants']['name']}")
 

--- a/vars/folioEdge.groovy
+++ b/vars/folioEdge.groovy
@@ -74,16 +74,16 @@ void renderEphemeralPropertiesEureka(RancherNamespace namespace) {
 
   common.logger.info("Response: " + json)
 
-  def dataToProcess = tools.steps.jsonParse(json)
+  def dataToProcess = tools.jsonParse(json as String)
 
   if ('fs09000000' in dataToProcess['tenants']['name']) { // to the mappings part
     mappings.add('fs09000000')
   } else {
     mappings.add('diku')
   }
-  def tenants = dataToProcess['tenants']['name']
+  def tenants = dataToProcess['tenants']
 
-  dataToProcess['tenants'].each { candidate -> // real existing tenant's metadata include
+  dataToProcess.each { candidate -> // real existing tenant's metadata include
     users += folioDefault.tenants()["${candidate['name']}"].tenantId + '=' + folioDefault.tenants()["${candidate['name']}"].getAdminUser() + ','
     +folioDefault.tenants()["${candidate['name']}"].getAdminUser().passwordPlainText + '\n'
   }

--- a/vars/folioEdge.groovy
+++ b/vars/folioEdge.groovy
@@ -97,7 +97,7 @@ void renderEphemeralPropertiesEureka(RancherNamespace namespace) {
     if (edgeConfig[name]['tenants']) {
       edgeConfig[name]['tenants'].each { institutional ->
         tenants.add(institutional.tenant)
-        users += "${(institutional.tenant == 'default' ? ${mappings.getAt(0)} : institutional.tenant)}=${institutional.username},${institutional.password}\n"
+        users += "${(institutional.tenant == 'default' ? mappings.getAt(0) : institutional.tenant)}=${institutional.username},${institutional.password}\n"
       }
     }
     LinkedHashMap config_data = [edge_tenants: "${tenants.join(",")}", edge_mappings: "${mappings.getAt(0)}", edge_users: users, institutional_users: 'test=test,test']

--- a/vars/folioEdge.groovy
+++ b/vars/folioEdge.groovy
@@ -85,8 +85,8 @@ void renderEphemeralPropertiesEureka(RancherNamespace namespace) {
   def tenants = dataToProcess['tenants']['name']
 
   dataToProcess['tenants'].each { candidate -> // real existing tenant's metadata include
-    users += folioDefault.tenants()["${candidate['name']}"].tenantId + '=' + folioDefault.tenants()["${candidate['name']}"].getAdminUser().username + ','
-    +folioDefault.tenants()["${candidate['name']}"].getAdminUser().passwordPlainText + '\n'
+    users += "${folioDefault.tenants()["${candidate['name']}"].tenantId}" + '=' + "${folioDefault.tenants()["${candidate['name']}"].getAdminUser().username}" + ','
+    + "${folioDefault.tenants()["${candidate['name']}"].getAdminUser().passwordPlainText}" + '\n'
   }
 
   edgeConfig['tenants'].each { institutional ->

--- a/vars/folioEdge.groovy
+++ b/vars/folioEdge.groovy
@@ -83,6 +83,7 @@ void renderEphemeralPropertiesEureka(RancherNamespace namespace) {
   } else {
     mappings.add('diku')
   }
+
   def tenants = dataToProcess['tenants']['name'] as List
 
   dataToProcess['tenants'].each { candidate -> // real existing tenant's metadata include
@@ -92,7 +93,6 @@ void renderEphemeralPropertiesEureka(RancherNamespace namespace) {
     common.logger.info("Tenant: " + candidate['name'] + " bind complete.")
   }
 
-  LinkedHashMap config_data = [edge_tenants: "${tenants.join(",")}", edge_mappings: "${mappings.getAt(0)}", edge_users: users, institutional_users: 'test=test,test']
   namespace.getModules().getEdgeModules().each { name, version ->
     if (edgeConfig[name]['tenants']) {
       edgeConfig[name]['tenants'].each { institutional ->
@@ -102,5 +102,6 @@ void renderEphemeralPropertiesEureka(RancherNamespace namespace) {
       tools.steps.writeFile file: "${name}-ephemeral-properties", text: (new StreamingTemplateEngine().createTemplate(config_template).make(config_data)).toString()
       common.logger.info("ephemeralProperties file for module ${name} created.")
     }
+    LinkedHashMap config_data = [edge_tenants: "${tenants.join(",")}", edge_mappings: "${mappings.getAt(0)}", edge_users: users, institutional_users: 'test=test,test']
   }
 }

--- a/vars/folioEdge.groovy
+++ b/vars/folioEdge.groovy
@@ -94,13 +94,14 @@ void renderEphemeralPropertiesEureka(RancherNamespace namespace) {
   }
 
   namespace.getModules().getEdgeModules().each { name, version ->
+    String institutionalUsers = ''
     if (edgeConfig[name]['tenants']) {
       edgeConfig[name]['tenants'].each { institutional ->
         tenants.add(institutional.tenant)
-        users += "${(institutional.tenant == 'default' ? mappings.getAt(0) : institutional.tenant)}=${institutional.username},${institutional.password}\n"
+        institutionalUsers += "${(institutional.tenant == 'default' ? mappings.getAt(0) : institutional.tenant)}=${institutional.username},${institutional.password}\n"
       }
     }
-    LinkedHashMap config_data = [edge_tenants: "${tenants.join(",")}", edge_mappings: "${mappings.getAt(0)}", edge_users: users, institutional_users: 'test=test,test']
+    LinkedHashMap config_data = [edge_tenants: "${tenants.join(",")}", edge_mappings: "${mappings.getAt(0)}", edge_users: users + institutionalUsers, institutional_users: 'test=test,test']
     tools.steps.writeFile file: "${name}-ephemeral-properties", text: (new StreamingTemplateEngine().createTemplate(config_template).make(config_data)).toString()
     common.logger.info("ephemeralProperties file for module ${name} created.")
   }

--- a/vars/folioEdge.groovy
+++ b/vars/folioEdge.groovy
@@ -97,11 +97,11 @@ void renderEphemeralPropertiesEureka(RancherNamespace namespace) {
     String institutionalUsers = ''
     if (edgeConfig[name]['tenants']) {
       edgeConfig[name]['tenants'].each { institutional ->
-        tenants.add(institutional.tenant)
+        institutional.tenant == 'default' ? '' : tenants.add(institutional.tenant)
         institutionalUsers += "${(institutional.tenant == 'default' ? mappings.getAt(0) : institutional.tenant)}=${institutional.username},${institutional.password}\n"
       }
     }
-    LinkedHashMap config_data = [edge_tenants: "${tenants.join(",")}", edge_mappings: "${mappings.getAt(0)}", edge_users: users + institutionalUsers, institutional_users: 'test=test,test']
+    LinkedHashMap config_data = [edge_tenants: "${tenants.join(",")}", edge_mappings: "${mappings.getAt(0)}", edge_users: users, institutional_users: institutionalUsers]
     tools.steps.writeFile file: "${name}-ephemeral-properties", text: (new StreamingTemplateEngine().createTemplate(config_template).make(config_data)).toString()
     common.logger.info("ephemeralProperties file for module ${name} created.")
   }

--- a/vars/folioEdge.groovy
+++ b/vars/folioEdge.groovy
@@ -97,7 +97,7 @@ void renderEphemeralPropertiesEureka(RancherNamespace namespace) {
     if (edgeConfig[name]['tenants']) {
       edgeConfig[name]['tenants'].each { institutional ->
         tenants.add(institutional.tenant)
-        users += institutional.tenant == 'default' ? "${mappings.getAt(0)}" : institutional.tenant + '=' + institutional.username + ',' + institutional.password + '\n'
+        users += "${(institutional.tenant == 'default' ? ${mappings.getAt(0)} : institutional.tenant)}=${institutional.username},${institutional.password}\n"
       }
     }
     LinkedHashMap config_data = [edge_tenants: "${tenants.join(",")}", edge_mappings: "${mappings.getAt(0)}", edge_users: users, institutional_users: 'test=test,test']

--- a/vars/folioEdge.groovy
+++ b/vars/folioEdge.groovy
@@ -87,16 +87,18 @@ void renderEphemeralPropertiesEureka(RancherNamespace namespace) {
   def tenants = dataToProcess['tenants']['name'] as List
 
   dataToProcess['tenants'].each { candidate -> // real existing tenant's metadata include
-    common.logger.info("Binding tenant: " + candidate['name'])
-    def tenant = folioDefault.tenants()[candidate['name']]
-    users += tenant.getTenantId() + '=' + tenant.getAdminUser().getUsername() + ',' + tenant.getAdminUser().getPasswordPlainText() + '\n'
-    common.logger.info("Tenant: " + candidate['name'] + " bind complete.")
+    if (candidate['name']) {
+      common.logger.info("Binding tenant: " + candidate['name'])
+      def tenant = folioDefault.tenants()[candidate['name']]
+      users += tenant.getTenantId() + '=' + tenant.getAdminUser().getUsername() + ',' + tenant.getAdminUser().getPasswordPlainText() + '\n'
+      common.logger.info("Tenant: " + candidate['name'] + " bind complete.")
+    }
   }
 
   namespace.getModules().getEdgeModules().each { name, version ->
     String institutionalUsers = ''
-    if (edgeConfig[name]['tenants']) {
-      edgeConfig[name]['tenants'].each { institutional ->
+    if (edgeConfig[(name)]['tenants']) {
+      edgeConfig[(name)]['tenants'].each { institutional ->
         institutional.tenant == 'default' ? '' : tenants.add(institutional.tenant)
         institutionalUsers += "${(institutional.tenant == 'default' ? mappings.getAt(0) : institutional.tenant)}=${institutional.username},${institutional.password}\n"
       }

--- a/vars/folioEdge.groovy
+++ b/vars/folioEdge.groovy
@@ -1,9 +1,7 @@
-import groovy.json.JsonSlurperClassic
 import groovy.text.StreamingTemplateEngine
 import org.folio.Constants
 import org.folio.models.RancherNamespace
 import org.folio.rest_v2.Common
-import org.folio.utilities.RestClient
 import org.folio.utilities.Tools
 
 /**
@@ -84,8 +82,6 @@ void renderEphemeralPropertiesEureka(RancherNamespace namespace) {
     mappings.add('diku')
   }
 
-  def tenants = dataToProcess['tenants']['name'] as List
-
   dataToProcess['tenants'].each { candidate -> // real existing tenant's metadata include
     if (candidate['name']) {
       common.logger.info("Binding tenant: " + candidate['name'])
@@ -96,6 +92,7 @@ void renderEphemeralPropertiesEureka(RancherNamespace namespace) {
   }
 
   namespace.getModules().getEdgeModules().each { name, version ->
+    def tenants = dataToProcess['tenants']['name'] as List
     String institutionalUsers = ''
     if (edgeConfig[(name)]['tenants']) {
       edgeConfig[(name)]['tenants'].each { institutional ->

--- a/vars/folioEdge.groovy
+++ b/vars/folioEdge.groovy
@@ -69,7 +69,7 @@ void renderEphemeralPropertiesEureka(RancherNamespace namespace) {
   List mappings = []
   String users = ''
 
-  def json = tools.steps.sh(script: "set +e && https://${namespace.generateDomain('kong')}/tenants", returnStdOut: true)
+  def json = tools.steps.sh(script: "set +e && curl https://${namespace.generateDomain('kong')}/tenants", returnStdOut: true)
 
   common.logger.info("Response: ${json}")
 

--- a/vars/folioEdge.groovy
+++ b/vars/folioEdge.groovy
@@ -69,13 +69,18 @@ void renderEphemeralPropertiesEureka(RancherNamespace namespace) {
   List mappings = []
   String users = ''
   RestClient client = new RestClient(this)
-  def json = client.get("https://${namespace.generateDomain('kong')}/tenants").body
+  Map headers = [
+    'x-okapi-tenant': 'fakeTenant'
+  ]
+
+  def json = client.get("https://${namespace.generateDomain('kong')}/tenants", headers).body
+
   if ('fs09000000' in json['tenants']['name']) { // to the mappings part
     mappings.add('fs09000000')
   } else {
     mappings.add('diku')
   }
-  def tenants = (json['tenants']['name']).join(",")
+  def tenants = json['tenants']['name']
 
   json['tenants']['name'].each { candidate -> // real existing tenant's metadata include
     users += folioDefault.tenants()["${candidate}"].tenantId + '=' + folioDefault.tenants()["${candidate}"].getAdminUser() + ','

--- a/vars/folioEdge.groovy
+++ b/vars/folioEdge.groovy
@@ -99,9 +99,9 @@ void renderEphemeralPropertiesEureka(RancherNamespace namespace) {
         tenants.add(institutional.tenant)
         users += institutional.tenant == 'default' ? "${mappings.getAt(0)}" : institutional.tenant + '=' + institutional.username + ',' + institutional.password + '\n'
       }
-      tools.steps.writeFile file: "${name}-ephemeral-properties", text: (new StreamingTemplateEngine().createTemplate(config_template).make(config_data)).toString()
-      common.logger.info("ephemeralProperties file for module ${name} created.")
     }
     LinkedHashMap config_data = [edge_tenants: "${tenants.join(",")}", edge_mappings: "${mappings.getAt(0)}", edge_users: users, institutional_users: 'test=test,test']
+    tools.steps.writeFile file: "${name}-ephemeral-properties", text: (new StreamingTemplateEngine().createTemplate(config_template).make(config_data)).toString()
+    common.logger.info("ephemeralProperties file for module ${name} created.")
   }
 }

--- a/vars/folioEdge.groovy
+++ b/vars/folioEdge.groovy
@@ -84,7 +84,9 @@ void renderEphemeralPropertiesEureka(RancherNamespace namespace) {
 
   edgeConfig['tenants'].each { institutional ->
     tenants.add(institutional.tenant)
-    users += institutional.tenant + '=' + institutional.username + ',' + institutional.password + '\n'
+    if (institutional.create) {
+      users += institutional.tenant == 'default' ? "${mappings.getAt(0)}" : institutional.tenant + '=' + institutional.username + ',' + institutional.password + '\n'
+    }
   }
 
   LinkedHashMap config_data = [edge_tenants: "${tenants.join(",")}", edge_mappings: "${mappings.getAt(0)}", edge_users: users, institutional_users: 'test=test,test']

--- a/vars/folioEdge.groovy
+++ b/vars/folioEdge.groovy
@@ -75,7 +75,7 @@ void renderEphemeralPropertiesEureka(RancherNamespace namespace) {
   } else {
     mappings.add('diku')
   }
-  def tenants = json['tenants']['name']
+  def tenants = json['tenants']['name'] as List
 
   json['tenants']['name'].each { candidate -> // real existing tenant's metadata include
     users += folioDefault.tenants()["${candidate}"].tenantId + '=' + folioDefault.tenants()["${candidate}"].getAdminUser() + ','

--- a/vars/folioEdge.groovy
+++ b/vars/folioEdge.groovy
@@ -76,7 +76,9 @@ void renderEphemeralPropertiesEureka(RancherNamespace namespace) {
 
   def dataToProcess = tools.jsonParse(json as String)
 
-  if ('fs09000000' in dataToProcess['tenants']['name']) { // to the mappings part
+  common.logger.info("List of existing tenants: ${dataToProcess.tenants.name}")
+
+  if ('fs09000000' in dataToProcess.tenants.name) { // to the mappings part
     mappings.add('fs09000000')
   } else {
     mappings.add('diku')

--- a/vars/folioEdge.groovy
+++ b/vars/folioEdge.groovy
@@ -75,7 +75,7 @@ void renderEphemeralPropertiesEureka(RancherNamespace namespace) {
   } else {
     mappings.add('diku')
   }
-  def tenants = json['tenants']['name'] as List
+  def tenants = (json['tenants']['name']).join(",")
 
   json['tenants']['name'].each { candidate -> // real existing tenant's metadata include
     users += folioDefault.tenants()["${candidate}"].tenantId + '=' + folioDefault.tenants()["${candidate}"].getAdminUser() + ','

--- a/vars/folioEdge.groovy
+++ b/vars/folioEdge.groovy
@@ -85,8 +85,8 @@ void renderEphemeralPropertiesEureka(RancherNamespace namespace) {
   def tenants = dataToProcess['tenants']['name']
 
   dataToProcess['tenants'].each { candidate -> // real existing tenant's metadata include
-    users += "${folioDefault.tenants()["${candidate['name']}"].tenantId}" + '=' + "${folioDefault.tenants()["${candidate['name']}"].getAdminUser().username}" + ','
-    + "${folioDefault.tenants()["${candidate['name']}"].getAdminUser().passwordPlainText}" + '\n'
+    users += "${folioDefault.tenants()["${candidate['name']}"].getTenantId()}" + '=' + "${folioDefault.tenants()["${candidate['name']}"].getAdminUser().getUsername()}" + ','
+    + "${folioDefault.tenants()["${candidate['name']}"].getAdminUser().getPasswordPlainText()}" + '\n'
   }
 
   edgeConfig['tenants'].each { institutional ->

--- a/vars/folioEdge.groovy
+++ b/vars/folioEdge.groovy
@@ -89,6 +89,8 @@ void renderEphemeralPropertiesEureka(RancherNamespace namespace) {
     }
   }
 
+  println(tenants)
+
   LinkedHashMap config_data = [edge_tenants: "${tenants.join(",")}", edge_mappings: "${mappings.getAt(0)}", edge_users: users, institutional_users: 'test=test,test']
   namespace.getModules().getEdgeModules().each { name, version ->
     tools.steps.writeFile file: "${name}-ephemeral-properties", text: (new StreamingTemplateEngine().createTemplate(config_template).make(config_data)).toString()

--- a/vars/folioEdge.groovy
+++ b/vars/folioEdge.groovy
@@ -89,7 +89,7 @@ void renderEphemeralPropertiesEureka(RancherNamespace namespace) {
     }
   }
 
-  println(tenants)
+  common.logger.warning(tenants)
 
   LinkedHashMap config_data = [edge_tenants: "${tenants.join(",")}", edge_mappings: "${mappings.getAt(0)}", edge_users: users, institutional_users: 'test=test,test']
   namespace.getModules().getEdgeModules().each { name, version ->

--- a/vars/folioEdge.groovy
+++ b/vars/folioEdge.groovy
@@ -76,7 +76,7 @@ void renderEphemeralPropertiesEureka(RancherNamespace namespace) {
 
   def dataToProcess = tools.jsonParse(json as String)
 
-  common.logger.info("List of existing tenants: ${dataToProcess.tenants.name}")
+  common.logger.info("List of existing tenants: ${dataToProcess['tenants'][0]['name']}")
 
   if ('fs09000000' in dataToProcess.tenants.name) { // to the mappings part
     mappings.add('fs09000000')

--- a/vars/folioEdge.groovy
+++ b/vars/folioEdge.groovy
@@ -97,11 +97,11 @@ void renderEphemeralPropertiesEureka(RancherNamespace namespace) {
     if (edgeConfig[(name)]['tenants']) {
       edgeConfig[(name)]['tenants'].each { institutional ->
         if (institutional.tenant == 'default') {
-          tenants.add(institutional.tenant)
           tenants.each { tenantName ->
             institutionalUsers += "${tenantName}=${institutional.username},${institutional.password}\n"
           }
         } else {
+          tenants.add(institutional.tenant)
           institutionalUsers += "${institutional.tenant}=${institutional.username},${institutional.password}\n"
         }
       }

--- a/vars/folioEdge.groovy
+++ b/vars/folioEdge.groovy
@@ -5,6 +5,7 @@ import org.folio.models.RancherNamespace
 import org.folio.rest_v2.Common
 import org.folio.utilities.RestClient
 import org.folio.utilities.Tools
+
 /**
  * Renders the ephemeral properties for a tenant.
  *
@@ -85,9 +86,12 @@ void renderEphemeralPropertiesEureka(RancherNamespace namespace) {
   def tenants = dataToProcess['tenants']['name']
 
   dataToProcess['tenants'].each { candidate -> // real existing tenant's metadata include
-    users += "${folioDefault.tenants()["${candidate['name']}"].getTenantId()}" + '=' + "${folioDefault.tenants()["${candidate['name']}"].getAdminUser().getUsername()}" + ','
-    + "${folioDefault.tenants()["${candidate['name']}"].getAdminUser().getPasswordPlainText()}" + '\n'
+    common.logger.info("Binding tenant: " + candidate['name'])
+    def tenant = folioDefault.tenants()[candidate['name']]
+    users += tenant.getTenantId() + '=' + tenant.getAdminUser().getUsername() + ',' + tenant.getAdminUser().getPasswordPlainText() + '\n'
+    common.logger.info("Tenant: " + candidate['name'] + " bind complete.")
   }
+
 
   edgeConfig['tenants'].each { institutional ->
     tenants.add(institutional.tenant)
@@ -95,8 +99,6 @@ void renderEphemeralPropertiesEureka(RancherNamespace namespace) {
       users += institutional.tenant == 'default' ? "${mappings.getAt(0)}" : institutional.tenant + '=' + institutional.username + ',' + institutional.password + '\n'
     }
   }
-
-  common.logger.warning(tenants)
 
   LinkedHashMap config_data = [edge_tenants: "${tenants.join(",")}", edge_mappings: "${mappings.getAt(0)}", edge_users: users, institutional_users: 'test=test,test']
   namespace.getModules().getEdgeModules().each { name, version ->

--- a/vars/folioEdge.groovy
+++ b/vars/folioEdge.groovy
@@ -69,22 +69,23 @@ void renderEphemeralPropertiesEureka(RancherNamespace namespace) {
   List mappings = []
   String users = ''
   RestClient client = new RestClient(this)
-  Map headers = [
-    'x-okapi-tenant': 'fakeTenant'
-  ]
 
-  def json = client.get("https://${namespace.generateDomain('kong')}/tenants", headers).body
+  def json = client.get("https://${namespace.generateDomain('kong')}/tenants").body
 
-  if ('fs09000000' in json['tenants']['name']) { // to the mappings part
+  common.logger.info("Response: " + json)
+
+  def dataToProcess = tools.steps.jsonParse(json)
+
+  if ('fs09000000' in dataToProcess['tenants']['name']) { // to the mappings part
     mappings.add('fs09000000')
   } else {
     mappings.add('diku')
   }
-  def tenants = json['tenants']['name']
+  def tenants = dataToProcess['tenants']['name']
 
-  json['tenants']['name'].each { candidate -> // real existing tenant's metadata include
-    users += folioDefault.tenants()["${candidate}"].tenantId + '=' + folioDefault.tenants()["${candidate}"].getAdminUser() + ','
-    +folioDefault.tenants()["${candidate}"].getAdminUser().passwordPlainText + '\n'
+  dataToProcess['tenants'].each { candidate -> // real existing tenant's metadata include
+    users += folioDefault.tenants()["${candidate['name']}"].tenantId + '=' + folioDefault.tenants()["${candidate['name']}"].getAdminUser() + ','
+    +folioDefault.tenants()["${candidate['name']}"].getAdminUser().passwordPlainText + '\n'
   }
 
   edgeConfig['tenants'].each { institutional ->

--- a/vars/folioNamespaceCreateEureka.groovy
+++ b/vars/folioNamespaceCreateEureka.groovy
@@ -210,7 +210,7 @@ void call(CreateNamespaceParameters args) {
 
     stage('[Helm] Deploy edge') {
       folioHelm.withKubeConfig(namespace.getClusterName()) {
-        folioEdge.renderEphemeralProperties(namespace)
+        folioEdge.renderEphemeralPropertiesEureka(namespace)
 
         namespace.getModules().getEdgeModules().each { name, version ->
           kubectl.createConfigMap("${name}-ephemeral-properties", namespace.getNamespaceName(), "./${name}-ephemeral-properties")

--- a/vars/folioNamespaceCreateEureka.groovy
+++ b/vars/folioNamespaceCreateEureka.groovy
@@ -213,7 +213,6 @@ void call(CreateNamespaceParameters args) {
         folioEdge.renderEphemeralPropertiesEureka(namespace)
 
         namespace.getModules().getEdgeModules().each { name, version ->
-          kubectl.deleteConfigMap("${name}-ephemeral-properties", "${namespace.getNamespaceName()}")
           kubectl.createConfigMap("${name}-ephemeral-properties", namespace.getNamespaceName(), "./${name}-ephemeral-properties")
         }
 

--- a/vars/folioNamespaceCreateEureka.groovy
+++ b/vars/folioNamespaceCreateEureka.groovy
@@ -213,7 +213,7 @@ void call(CreateNamespaceParameters args) {
         folioEdge.renderEphemeralPropertiesEureka(namespace)
 
         namespace.getModules().getEdgeModules().each { name, version ->
-          kubectl.deleteConfigMap("${name}", "${namespace.getNamespaceName()}")
+          kubectl.deleteConfigMap("${name}-ephemeral-properties", "${namespace.getNamespaceName()}")
           kubectl.createConfigMap("${name}-ephemeral-properties", namespace.getNamespaceName(), "./${name}-ephemeral-properties")
         }
 

--- a/vars/folioNamespaceCreateEureka.groovy
+++ b/vars/folioNamespaceCreateEureka.groovy
@@ -35,9 +35,9 @@ void call(CreateNamespaceParameters args) {
     tfConfig.addVar('pg_version', args.pgVersion)
     tfConfig.addVar('eureka', args.eureka)
 
-    stage('[Terraform] Provision') {
-      folioTerraformFlow.manageNamespace('apply', tfConfig)
-    }
+//    stage('[Terraform] Provision') {
+//      folioTerraformFlow.manageNamespace('apply', tfConfig)
+//    }
 
     if (args.greenmail) {
       stage('[Helm] Deploy greenmail') {
@@ -117,70 +117,70 @@ void call(CreateNamespaceParameters args) {
     }
 
     // TODO: Move this part to one of Eureka classes later. | DO NOT REMOVE | FIX FOR DNS PROPAGATION ISSUE!!!
-    timeout(time: 25, unit: 'MINUTES') {
-      def check = ''
-
-      while (check == '') {
-        try {
-          check = sh(script: "curl --fail --silent https://${namespace.generateDomain('keycloak')}/admin/master/console/", returnStdout: true).trim()
-          return check
-        } catch (ignored) {
-          logger.debug("DNS record: ${namespace.generateDomain('keycloak')} still not propagated!")
-          sleep time: 5, unit: "SECONDS"
-        }
-      }
-    }
+//    timeout(time: 25, unit: 'MINUTES') {
+//      def check = ''
+//
+//      while (check == '') {
+//        try {
+//          check = sh(script: "curl --fail --silent https://${namespace.generateDomain('keycloak')}/admin/master/console/", returnStdout: true).trim()
+//          return check
+//        } catch (ignored) {
+//          logger.debug("DNS record: ${namespace.generateDomain('keycloak')} still not propagated!")
+//          sleep time: 5, unit: "SECONDS"
+//        }
+//      }
+//    }
 
     //Don't move from here because it increases Keycloak TTL before mgr modules to be deployed
     Eureka eureka = new Eureka(this, namespace.generateDomain('kong'), namespace.generateDomain('keycloak'))
       .defineKeycloakTTL()
 
     // TODO: Below [ASG] stage could be moved to one the shared libs and called with an appropriate parameters.
-    stage('[ASG] configure') {
-      folioHelm.withKubeConfig(namespace.getClusterName()) {
-        def nodes_before = sh(script: "kubectl get nodes --no-headers | wc -l", returnStdout: true).trim()
+//    stage('[ASG] configure') {
+//      folioHelm.withKubeConfig(namespace.getClusterName()) {
+//        def nodes_before = sh(script: "kubectl get nodes --no-headers | wc -l", returnStdout: true).trim()
+//
+//        def asg_json = sh(script: "aws autoscaling describe-auto-scaling-groups " +
+//          "--filters \"Name=tag:\"eks:cluster-name\",Values=${namespace.getClusterName()}\" " +
+//          "--region ${Constants.AWS_REGION}", returnStdout: true)
+//        writeJSON file: 'asg.json', json: asg_json
+//        def asg_data = readJSON file: './asg.json'
+//        sh(script: "aws autoscaling set-desired-capacity " +
+//          "--auto-scaling-group-name ${asg_data.AutoScalingGroups[0].AutoScalingGroupName} " +
+//          "--desired-capacity ${asg_data.AutoScalingGroups[0].DesiredCapacity + 1} " +
+//          "--region ${Constants.AWS_REGION}")
+//
+//        //Make sure that the new node has joined target EKS cluster
+//        def nodes_after = sh(script: "kubectl get nodes --no-headers | wc -l", returnStdout: true).trim()
+//
+//        while (nodes_before.toInteger() == nodes_after.toInteger()) {
+//          logger.debug("New worker node is joining to cluster: ${namespace.getClusterName()}...")
+//          nodes_after = sh(script: "kubectl get nodes --no-headers | wc -l", returnStdout: true).trim()
+//          sleep time: 10, unit: "SECONDS"
+//        }
+//      }
+//    }
 
-        def asg_json = sh(script: "aws autoscaling describe-auto-scaling-groups " +
-          "--filters \"Name=tag:\"eks:cluster-name\",Values=${namespace.getClusterName()}\" " +
-          "--region ${Constants.AWS_REGION}", returnStdout: true)
-        writeJSON file: 'asg.json', json: asg_json
-        def asg_data = readJSON file: './asg.json'
-        sh(script: "aws autoscaling set-desired-capacity " +
-          "--auto-scaling-group-name ${asg_data.AutoScalingGroups[0].AutoScalingGroupName} " +
-          "--desired-capacity ${asg_data.AutoScalingGroups[0].DesiredCapacity + 1} " +
-          "--region ${Constants.AWS_REGION}")
-
-        //Make sure that the new node has joined target EKS cluster
-        def nodes_after = sh(script: "kubectl get nodes --no-headers | wc -l", returnStdout: true).trim()
-
-        while (nodes_before.toInteger() == nodes_after.toInteger()) {
-          logger.debug("New worker node is joining to cluster: ${namespace.getClusterName()}...")
-          nodes_after = sh(script: "kubectl get nodes --no-headers | wc -l", returnStdout: true).trim()
-          sleep time: 10, unit: "SECONDS"
-        }
-      }
-    }
-
-    stage('[Helm] Deploy mgr-*') {
-      folioHelm.withKubeConfig(namespace.getClusterName()) {
-        folioHelm.deployFolioModulesParallel(namespace, namespace.getModules().getMgrModules())
-      }
-    }
+//    stage('[Helm] Deploy mgr-*') {
+//      folioHelm.withKubeConfig(namespace.getClusterName()) {
+//        folioHelm.deployFolioModulesParallel(namespace, namespace.getModules().getMgrModules())
+//      }
+//    }
 
     stage('[Rest] Preinstall') {
-      namespace.withApplications(
-        eureka.registerApplicationsFlow(
-          args.consortia ? eureka.CURRENT_APPLICATIONS : eureka.CURRENT_APPLICATIONS_WO_CONSORTIA
-          , namespace.getModules()
-          , namespace.getTenants().values() as List<EurekaTenant>
-        )
-      )
-
-      eureka.registerModulesFlow(
-              namespace.getModules()
-              , namespace.getApplications()
-              , namespace.getTenants().values() as List<EurekaTenant>
-      )
+//      namespace.withApplications(
+//        eureka.registerApplicationsFlow(
+//          args.consortia ? eureka.CURRENT_APPLICATIONS : eureka.CURRENT_APPLICATIONS_WO_CONSORTIA
+//          , namespace.getModules()
+//          , namespace.getTenants().values() as List<EurekaTenant>
+//        )
+//      )
+//
+//      eureka.registerModulesFlow(
+//              namespace.getModules()
+//              , namespace.getApplications()
+//              , namespace.getTenants().values() as List<EurekaTenant>
+//      )
 
 //      namespace.withApplications([
 //        "app-platform-full": "app-platform-full-1.0.0-SNAPSHOT.660"
@@ -200,46 +200,47 @@ void call(CreateNamespaceParameters args) {
 //      }
     }
 
-    stage('[Helm] Deploy modules') {
-      folioHelm.withKubeConfig(namespace.getClusterName()) {
-        logger.info(namespace.getModules().getBackendModules())
-
-        folioHelm.deployFolioModulesParallel(namespace, namespace.getModules().getBackendModules())
-      }
-    }
+//    stage('[Helm] Deploy modules') {
+//      folioHelm.withKubeConfig(namespace.getClusterName()) {
+//        logger.info(namespace.getModules().getBackendModules())
+//
+//        folioHelm.deployFolioModulesParallel(namespace, namespace.getModules().getBackendModules())
+//      }
+//    }
 
     stage('[Helm] Deploy edge') {
       folioHelm.withKubeConfig(namespace.getClusterName()) {
         folioEdge.renderEphemeralPropertiesEureka(namespace)
 
         namespace.getModules().getEdgeModules().each { name, version ->
+          kubectl.deleteConfigMap("${name}", "${namespace.getNamespaceName()}")
           kubectl.createConfigMap("${name}-ephemeral-properties", namespace.getNamespaceName(), "./${name}-ephemeral-properties")
         }
 
-        retry(3) {
-          folioHelm.deployFolioModulesParallel(namespace, namespace.getModules().getEdgeModules())
-        }
+//        retry(3) {
+//          folioHelm.deployFolioModulesParallel(namespace, namespace.getModules().getEdgeModules())
+//        }
       }
     }
 
-    stage('[Rest] Initialize') {
-      int counter = 0
-      retry(10) {
-        // The first wait time should be at least 10 minutes due to module's long time instantiation
-        sleep time: (counter == 0 ? 10 : 2), unit: 'MINUTES'
-        counter++
-
-        eureka.initializeFromScratch(
-                namespace.getTenants()
-                , namespace.getClusterName()
-                , namespace.getNamespaceName()
-                , namespace.getEnableConsortia()
-        )
-      }
-    }
+//    stage('[Rest] Initialize') {
+//      int counter = 0
+//      retry(10) {
+//        // The first wait time should be at least 10 minutes due to module's long time instantiation
+//        sleep time: (counter == 0 ? 10 : 2), unit: 'MINUTES'
+//        counter++
+//
+//        eureka.initializeFromScratch(
+//                namespace.getTenants()
+//                , namespace.getClusterName()
+//                , namespace.getNamespaceName()
+//                , namespace.getEnableConsortia()
+//        )
+//      }
+//    }
 
     stage('[Rest] Configure edge') {
-      new Edge(this, "${namespace.generateDomain('kong')}", "${namespace.generateDomain('keycloak')}").createEurekaUsers(namespace)
+//      new Edge(this, "${namespace.generateDomain('kong')}", "${namespace.generateDomain('keycloak')}").createEurekaUsers(namespace)
     }
 
     if (args.uiBuild) {

--- a/vars/folioNamespaceCreateEureka.groovy
+++ b/vars/folioNamespaceCreateEureka.groovy
@@ -35,9 +35,9 @@ void call(CreateNamespaceParameters args) {
     tfConfig.addVar('pg_version', args.pgVersion)
     tfConfig.addVar('eureka', args.eureka)
 
-//    stage('[Terraform] Provision') {
-//      folioTerraformFlow.manageNamespace('apply', tfConfig)
-//    }
+    stage('[Terraform] Provision') {
+      folioTerraformFlow.manageNamespace('apply', tfConfig)
+    }
 
     if (args.greenmail) {
       stage('[Helm] Deploy greenmail') {
@@ -117,70 +117,70 @@ void call(CreateNamespaceParameters args) {
     }
 
     // TODO: Move this part to one of Eureka classes later. | DO NOT REMOVE | FIX FOR DNS PROPAGATION ISSUE!!!
-//    timeout(time: 25, unit: 'MINUTES') {
-//      def check = ''
-//
-//      while (check == '') {
-//        try {
-//          check = sh(script: "curl --fail --silent https://${namespace.generateDomain('keycloak')}/admin/master/console/", returnStdout: true).trim()
-//          return check
-//        } catch (ignored) {
-//          logger.debug("DNS record: ${namespace.generateDomain('keycloak')} still not propagated!")
-//          sleep time: 5, unit: "SECONDS"
-//        }
-//      }
-//    }
+    timeout(time: 25, unit: 'MINUTES') {
+      def check = ''
+
+      while (check == '') {
+        try {
+          check = sh(script: "curl --fail --silent https://${namespace.generateDomain('keycloak')}/admin/master/console/", returnStdout: true).trim()
+          return check
+        } catch (ignored) {
+          logger.debug("DNS record: ${namespace.generateDomain('keycloak')} still not propagated!")
+          sleep time: 5, unit: "SECONDS"
+        }
+      }
+    }
 
     //Don't move from here because it increases Keycloak TTL before mgr modules to be deployed
     Eureka eureka = new Eureka(this, namespace.generateDomain('kong'), namespace.generateDomain('keycloak'))
       .defineKeycloakTTL()
 
     // TODO: Below [ASG] stage could be moved to one the shared libs and called with an appropriate parameters.
-//    stage('[ASG] configure') {
-//      folioHelm.withKubeConfig(namespace.getClusterName()) {
-//        def nodes_before = sh(script: "kubectl get nodes --no-headers | wc -l", returnStdout: true).trim()
-//
-//        def asg_json = sh(script: "aws autoscaling describe-auto-scaling-groups " +
-//          "--filters \"Name=tag:\"eks:cluster-name\",Values=${namespace.getClusterName()}\" " +
-//          "--region ${Constants.AWS_REGION}", returnStdout: true)
-//        writeJSON file: 'asg.json', json: asg_json
-//        def asg_data = readJSON file: './asg.json'
-//        sh(script: "aws autoscaling set-desired-capacity " +
-//          "--auto-scaling-group-name ${asg_data.AutoScalingGroups[0].AutoScalingGroupName} " +
-//          "--desired-capacity ${asg_data.AutoScalingGroups[0].DesiredCapacity + 1} " +
-//          "--region ${Constants.AWS_REGION}")
-//
-//        //Make sure that the new node has joined target EKS cluster
-//        def nodes_after = sh(script: "kubectl get nodes --no-headers | wc -l", returnStdout: true).trim()
-//
-//        while (nodes_before.toInteger() == nodes_after.toInteger()) {
-//          logger.debug("New worker node is joining to cluster: ${namespace.getClusterName()}...")
-//          nodes_after = sh(script: "kubectl get nodes --no-headers | wc -l", returnStdout: true).trim()
-//          sleep time: 10, unit: "SECONDS"
-//        }
-//      }
-//    }
+    stage('[ASG] configure') {
+      folioHelm.withKubeConfig(namespace.getClusterName()) {
+        def nodes_before = sh(script: "kubectl get nodes --no-headers | wc -l", returnStdout: true).trim()
 
-//    stage('[Helm] Deploy mgr-*') {
-//      folioHelm.withKubeConfig(namespace.getClusterName()) {
-//        folioHelm.deployFolioModulesParallel(namespace, namespace.getModules().getMgrModules())
-//      }
-//    }
+        def asg_json = sh(script: "aws autoscaling describe-auto-scaling-groups " +
+          "--filters \"Name=tag:\"eks:cluster-name\",Values=${namespace.getClusterName()}\" " +
+          "--region ${Constants.AWS_REGION}", returnStdout: true)
+        writeJSON file: 'asg.json', json: asg_json
+        def asg_data = readJSON file: './asg.json'
+        sh(script: "aws autoscaling set-desired-capacity " +
+          "--auto-scaling-group-name ${asg_data.AutoScalingGroups[0].AutoScalingGroupName} " +
+          "--desired-capacity ${asg_data.AutoScalingGroups[0].DesiredCapacity + 1} " +
+          "--region ${Constants.AWS_REGION}")
+
+        //Make sure that the new node has joined target EKS cluster
+        def nodes_after = sh(script: "kubectl get nodes --no-headers | wc -l", returnStdout: true).trim()
+
+        while (nodes_before.toInteger() == nodes_after.toInteger()) {
+          logger.debug("New worker node is joining to cluster: ${namespace.getClusterName()}...")
+          nodes_after = sh(script: "kubectl get nodes --no-headers | wc -l", returnStdout: true).trim()
+          sleep time: 10, unit: "SECONDS"
+        }
+      }
+    }
+
+    stage('[Helm] Deploy mgr-*') {
+      folioHelm.withKubeConfig(namespace.getClusterName()) {
+        folioHelm.deployFolioModulesParallel(namespace, namespace.getModules().getMgrModules())
+      }
+    }
 
     stage('[Rest] Preinstall') {
-//      namespace.withApplications(
-//        eureka.registerApplicationsFlow(
-//          args.consortia ? eureka.CURRENT_APPLICATIONS : eureka.CURRENT_APPLICATIONS_WO_CONSORTIA
-//          , namespace.getModules()
-//          , namespace.getTenants().values() as List<EurekaTenant>
-//        )
-//      )
-//
-//      eureka.registerModulesFlow(
-//              namespace.getModules()
-//              , namespace.getApplications()
-//              , namespace.getTenants().values() as List<EurekaTenant>
-//      )
+      namespace.withApplications(
+        eureka.registerApplicationsFlow(
+          args.consortia ? eureka.CURRENT_APPLICATIONS : eureka.CURRENT_APPLICATIONS_WO_CONSORTIA
+          , namespace.getModules()
+          , namespace.getTenants().values() as List<EurekaTenant>
+        )
+      )
+
+      eureka.registerModulesFlow(
+              namespace.getModules()
+              , namespace.getApplications()
+              , namespace.getTenants().values() as List<EurekaTenant>
+      )
 
 //      namespace.withApplications([
 //        "app-platform-full": "app-platform-full-1.0.0-SNAPSHOT.660"
@@ -200,13 +200,13 @@ void call(CreateNamespaceParameters args) {
 //      }
     }
 
-//    stage('[Helm] Deploy modules') {
-//      folioHelm.withKubeConfig(namespace.getClusterName()) {
-//        logger.info(namespace.getModules().getBackendModules())
-//
-//        folioHelm.deployFolioModulesParallel(namespace, namespace.getModules().getBackendModules())
-//      }
-//    }
+    stage('[Helm] Deploy modules') {
+      folioHelm.withKubeConfig(namespace.getClusterName()) {
+        logger.info(namespace.getModules().getBackendModules())
+
+        folioHelm.deployFolioModulesParallel(namespace, namespace.getModules().getBackendModules())
+      }
+    }
 
     stage('[Helm] Deploy edge') {
       folioHelm.withKubeConfig(namespace.getClusterName()) {
@@ -217,30 +217,30 @@ void call(CreateNamespaceParameters args) {
           kubectl.createConfigMap("${name}-ephemeral-properties", namespace.getNamespaceName(), "./${name}-ephemeral-properties")
         }
 
-//        retry(3) {
-//          folioHelm.deployFolioModulesParallel(namespace, namespace.getModules().getEdgeModules())
-//        }
+        retry(3) {
+          folioHelm.deployFolioModulesParallel(namespace, namespace.getModules().getEdgeModules())
+        }
       }
     }
 
-//    stage('[Rest] Initialize') {
-//      int counter = 0
-//      retry(10) {
-//        // The first wait time should be at least 10 minutes due to module's long time instantiation
-//        sleep time: (counter == 0 ? 10 : 2), unit: 'MINUTES'
-//        counter++
-//
-//        eureka.initializeFromScratch(
-//                namespace.getTenants()
-//                , namespace.getClusterName()
-//                , namespace.getNamespaceName()
-//                , namespace.getEnableConsortia()
-//        )
-//      }
-//    }
+    stage('[Rest] Initialize') {
+      int counter = 0
+      retry(10) {
+        // The first wait time should be at least 10 minutes due to module's long time instantiation
+        sleep time: (counter == 0 ? 10 : 2), unit: 'MINUTES'
+        counter++
+
+        eureka.initializeFromScratch(
+                namespace.getTenants()
+                , namespace.getClusterName()
+                , namespace.getNamespaceName()
+                , namespace.getEnableConsortia()
+        )
+      }
+    }
 
     stage('[Rest] Configure edge') {
-//      new Edge(this, "${namespace.generateDomain('kong')}", "${namespace.generateDomain('keycloak')}").createEurekaUsers(namespace)
+      new Edge(this, "${namespace.generateDomain('kong')}", "${namespace.generateDomain('keycloak')}").createEurekaUsers(namespace)
     }
 
     if (args.uiBuild) {


### PR DESCRIPTION
Questions:

- Why do we need to make it in this way?
- Why do we have to make Api call?

Answers:

- Currently used approach does not work & always we have to modify EP file to make edge-* modules work.
-  For Eureka based sprint testing, there was a request to make different tenants' structure, so to avoid a mess in EP file, we need to include ONLY existing tenants.

DETAILS:

- Full testing was complete in https://jenkins-aws.indexdata.com/view/KitFox/job/folioRancher/job/tmpFolderForDraftPipelines/job/EldiiarD/job/RANCHER-1770/
- Screenshots:
![image](https://github.com/user-attachments/assets/e3181898-29b2-46fa-9f54-8c162cac8c63)
![image](https://github.com/user-attachments/assets/3655ce0d-e8c6-4fd4-981c-4472f2be786e)


P\S as usual comments & suggestions are HIGLY APPRECIATED.
