### PR TITLE
RANCHER-1933: extend extraJavaOpts for mod-oai-pmh

### DIFF
--- a/resources/helm/development.yaml
+++ b/resources/helm/development.yaml
@@ -2106,6 +2106,7 @@ mod-oai-pmh:
       memory: 908Mi
   extraJavaOpts:
   - -XX:MaxRAMPercentage=85.0
+  - -Dfile.encoding=UTF-8
   startupProbe:
     httpGet:
       path: /admin/health

--- a/resources/helm/performance.yaml
+++ b/resources/helm/performance.yaml
@@ -2449,6 +2449,7 @@ mod-oai-pmh:
     targetMemoryUtilizationPercentage: 70
   extraJavaOpts:
   - -XX:MaxRAMPercentage=80.0
+  - -Dfile.encoding=UTF-8
   startupProbe:
     httpGet:
       path: /admin/health

--- a/resources/helm/testing.yaml
+++ b/resources/helm/testing.yaml
@@ -2455,6 +2455,7 @@ mod-oai-pmh:
     targetMemoryUtilizationPercentage: 70
   extraJavaOpts:
   - -XX:MaxRAMPercentage=80.0
+  - -Dfile.encoding=UTF-8
   startupProbe:
     httpGet:
       path: /admin/health


### PR DESCRIPTION
[RANCHER-1933: Start mod-oai-pmh module with -Dfile.encoding=UTF-8](https://folio-org.atlassian.net/browse/RANCHER-1933)