### PR TITLE
RANCHER-1831. A new recreateTeamNamespace pipeline to recreate the dev team environments based on a cron schedule.

### DIFF
--- a/pipelines/folioRancher/folioNamespaceTools/manageNamespace/recreateTeamNamespace/Jenkinsfile
+++ b/pipelines/folioRancher/folioNamespaceTools/manageNamespace/recreateTeamNamespace/Jenkinsfile
@@ -1,0 +1,91 @@
+#!groovy
+package folioRancher.folioNamespaceTools.manageNamespace.recreateTeamNamespace
+
+import groovy.transform.Field
+import org.folio.Constants
+import org.jenkinsci.plugins.workflow.libs.Library
+import org.folio.models.parameters.CreateNamespaceParameters
+
+//TODO remove branch before merge to master
+@Library('pipelines-shared-library@RANCHER-1334') _
+
+@Field final String deleteNamespaceJobNameEureka = Constants.JENKINS_DELETE_NAMESPACE_JOB_EUREKA
+@Field final String createNamespaceJobNameEureka = Constants.JENKINS_CREATE_NAMESPACE_FROM_BRANCH_JOB_EUREKA
+
+@Field final String deleteNamespaceJobName = Constants.JENKINS_DELETE_NAMESPACE_JOB
+@Field final String createNamespaceJobName = Constants.JENKINS_CREATE_NAMESPACE_FROM_BRANCH_JOB
+
+properties([buildDiscarder(logRotator(numToKeepStr: '30')),
+            disableConcurrentBuilds(),
+            parameters([folioParameters.cluster(),
+                        folioParameters.namespace(),
+                        folioParameters.configType(),
+                        booleanParam(name: 'EUREKA', defaultValue: false, description: '(Optional) Set true to enable EUREKA'),
+                        folioParameters.agent(),
+                        folioParameters.refreshParameters()]),
+            pipelineTriggers([parameterizedCron('''
+              H 20 * * * %CLUSTER=folio-etesting;NAMESPACE=eureka;EUREKA=true;AGENT=rancher
+            ''')])])
+
+
+if (params.REFRESH_PARAMETERS) {
+  currentBuild.result = 'ABORTED'
+  return
+}
+
+CreateNamespaceParameters namespace = new CreateNamespaceParameters.Builder()
+  .clusterName(params.CLUSTER)
+  .namespaceName(params.NAMESPACE)
+  .folioBranch('snapshot')
+  .okapiVersion('latest')
+  .configType('development')
+  .loadReference(true)
+  .loadSample(true)
+  .consortia(true)
+  .linkedData(true)
+  .eureka(params.EUREKA)
+  .rwSplit(false)
+  .greenmail(false)
+  .mockServer(false)
+  .rtr(false)
+  .ecsCCL(false)
+  .pgType('built-in')
+  .pgVersion('16.1')
+  .kafkaType('built-in')
+  .opensearchType('aws')
+  .s3Type('built-in')
+  .uiBuild(true)
+  .worker('rancher')
+  .runSanityCheck(true)
+  .build()
+
+ansiColor('xterm') {
+  node(params.AGENT) {
+    try {
+      stage('Checkout') {
+        checkout scm
+      }
+
+      stage('Build name') {
+        buildName "${namespace.getClusterName()}-${namespace.getNamespaceName()}.${env.BUILD_ID}"
+        buildDescription "Config: development"
+      }
+
+      stage('Cleaning env') {
+        folioTriggerJob.deleteNamespace(params.EUREKA ? deleteNamespaceJobNameEureka : deleteNamespaceJobName, namespace)
+      }
+
+      stage('Spinning up env') {
+        folioTriggerJob.createNamespaceFromBranch(params.EUREKA ? createNamespaceJobNameEureka : createNamespaceJobName, namespace)
+      }
+
+    } catch (e) {
+      println "Caught exception: ${e}"
+      error(e.getMessage())
+    } finally {
+      stage('Cleanup') {
+        cleanWs notFailBuild: true
+      }
+    }
+  }
+}

--- a/pipelines/folioRancher/folioNamespaceTools/manageNamespace/recreateTeamNamespace/Jenkinsfile
+++ b/pipelines/folioRancher/folioNamespaceTools/manageNamespace/recreateTeamNamespace/Jenkinsfile
@@ -24,7 +24,7 @@ properties([buildDiscarder(logRotator(numToKeepStr: '30')),
                         folioParameters.agent(),
                         folioParameters.refreshParameters()]),
             pipelineTriggers([parameterizedCron('''
-              H 20 * * * %CLUSTER=folio-etesting;NAMESPACE=eureka;EUREKA=true;AGENT=rancher
+              H 20 * * * %CLUSTER=folio-etesting;NAMESPACE=eureka;EUREKA=true;CONFIG_TYPE=development;AGENT=rancher
             ''')])])
 
 
@@ -38,7 +38,7 @@ CreateNamespaceParameters namespace = new CreateNamespaceParameters.Builder()
   .namespaceName(params.NAMESPACE)
   .folioBranch('snapshot')
   .okapiVersion('latest')
-  .configType('development')
+  .configType(params.CONFIG_TYPE)
   .loadReference(true)
   .loadSample(true)
   .consortia(true)

--- a/pipelines/folioRancher/folioNamespaceTools/manageNamespace/recreateTeamNamespace/Jenkinsfile
+++ b/pipelines/folioRancher/folioNamespaceTools/manageNamespace/recreateTeamNamespace/Jenkinsfile
@@ -24,7 +24,7 @@ properties([buildDiscarder(logRotator(numToKeepStr: '30')),
                         folioParameters.agent(),
                         folioParameters.refreshParameters()]),
             pipelineTriggers([parameterizedCron('''
-              H 20 * * * %CLUSTER=folio-etesting;NAMESPACE=eureka;EUREKA=true;CONFIG_TYPE=development;AGENT=rancher
+              H 20 * * * %CLUSTER=folio-edev;NAMESPACE=eureka;EUREKA=true;CONFIG_TYPE=development;AGENT=rancher
             ''')])])
 
 


### PR DESCRIPTION
The new pipeline resides here:
https://jenkins-aws.indexdata.com/job/folioRancher/job/tmpFolderForDraftPipelines/job/Eureka/job/recreateTeamNamespace/

Tested:
https://jenkins-aws.indexdata.com/job/folioRancher/job/tmpFolderForDraftPipelines/job/Eureka/job/recreateTeamNamespace/3/console

It can be applied to other environments by changing the following part:
![image](https://github.com/user-attachments/assets/57f70c70-b0f4-49fc-93dd-1f5d028ccc47)