### PR TITLE
RANCHER-1883. Add retrying workaround for entitle applications on tenant in case one from the list was previously entitled and the same approach for the capabilities assignment.

### DIFF
--- a/src/org/folio/rest_v2/eureka/Eureka.groovy
+++ b/src/org/folio/rest_v2/eureka/Eureka.groovy
@@ -47,7 +47,14 @@ class Eureka extends Base {
 
     kong.keycloak.defineTTL(tenant.tenantId, 3600)
 
-    Tenants.get(kong).enableApplicationsOnTenant(tenant)
+    List<String> entitledApps = Tenants.get(kong).getEnabledApplications(tenant).keySet().toList().collect { appId ->
+      appId.split("-\\d+\\.\\d+\\.\\d+")[0]
+    }
+
+    Tenants.get(kong).enableApplicationsOnTenant(
+      tenant
+      , tenant.applications.values().toList().findAll{app -> !(entitledApps.contains(app.split("-\\d+\\.\\d+\\.\\d+")[0]))}
+    )
 
     context.folioTools.stsKafkaLag(cluster, namespace, tenant.tenantId)
 

--- a/src/org/folio/rest_v2/eureka/Eureka.groovy
+++ b/src/org/folio/rest_v2/eureka/Eureka.groovy
@@ -101,9 +101,15 @@ class Eureka extends Base {
         .getUuid()
     )
 
-    Permissions.get(kong).assignCapabilitiesToRole(tenant, role, permissions, true)
-      .assignCapabilitySetsToRole(tenant, role, permissionSets, true)
-      .assignRolesToUser(tenant, user, [role])
+    Permissions.get(kong).assignCapabilitiesToRole(
+            tenant
+            , role
+            , permissions - Permissions.get(kong).getRoleCapabilitiesId(tenant, role)
+    ).assignCapabilitySetsToRole(
+            tenant
+            , role
+            , permissionSets - Permissions.get(kong).getRoleCapabilitySetsId(tenant, role)
+    ).assignRolesToUser(tenant, user, [role])
 
     Users.get(kong).getAndAssignSPs(tenant, user)
 

--- a/src/org/folio/rest_v2/eureka/kong/Tenants.groovy
+++ b/src/org/folio/rest_v2/eureka/kong/Tenants.groovy
@@ -109,8 +109,9 @@ class Tenants extends Kong{
     return getTenant(tenantId) ? true : false
   }
 
-  //TODO: Remove this shit
-  Tenants enableApplicationOnTenant(EurekaTenant tenant, String appId){
+  Tenants enableApplicationsOnTenant(EurekaTenant tenant, List<String> appIds){
+    if(!appIds)
+      return
 
     logger.info("Enable (entitle) applications on tenant ${tenant.tenantId} with ${tenant.uuid}...")
 
@@ -118,7 +119,7 @@ class Tenants extends Kong{
 
     Map body = [
       tenantId    : tenant.uuid,
-      applications: [appId]
+      applications: appIds
     ]
 
     logger.debug("enableApplicationsOnTenant body: ${body}")
@@ -129,46 +130,9 @@ class Tenants extends Kong{
       generateUrl("/entitlements${tenant.getInstallRequestParams()?.toQueryString() ?: ''}")
       , body
       , headers
-      , [201, 400]
     )
 
-    String contentStr = response.body.toString()
-
-    if (response.responseCode == 400) {
-      if (contentStr.contains("value: Entitle flow finished")) {
-        logger.info("""
-          Application is already entitled, no actions needed..
-          Status: ${response.responseCode}
-          Response content:
-          ${contentStr}""")
-
-        return this
-      } else {
-        logger.error("Enabling application for tenant failed: ${contentStr}")
-
-        throw new Exception("Build failed: " + contentStr)
-      }
-    }
-
     logger.info("Enabling (entitle) applications on tenant ${tenant.tenantId} with ${tenant.uuid} were finished successfully")
-
-    return this
-  }
-
-  //TODO: This shit definitely should be refactored
-  Tenants enableApplicationsOnTenant(EurekaTenant tenant){
-    logger.info("Enable (entitle) applications on tenant ${tenant.tenantId} with ${tenant.uuid}...")
-
-    enableApplicationOnTenant(tenant, tenant.applications["app-platform-full"])
-
-    if(tenant.applications.containsKey("app-linked-data"))
-      enableApplicationOnTenant(tenant, tenant.applications["app-linked-data"])
-
-    if(tenant.applications.containsKey("app-consortia"))
-      enableApplicationOnTenant(tenant, tenant.applications["app-consortia"])
-
-    if(tenant.applications.containsKey("app-consortia-manager"))
-      enableApplicationOnTenant(tenant, tenant.applications["app-consortia-manager"])
 
     return this
   }


### PR DESCRIPTION
Tested:
https://jenkins-aws.indexdata.com/job/folioRancher/job/tmpFolderForDraftPipelines/job/VasylA/job/createNamespaceFromBranch-Eureka-1883/39/console