### PR TITLE
[RANCHER-1692: Extend slack notification for FAILED status] (https://folio-org.atlassian.net/browse/RANCHER-1692)

### DIFF
--- a/pipelines/folioRancher/folioQualityGates/Jenkinsfile
+++ b/pipelines/folioRancher/folioQualityGates/Jenkinsfile
@@ -219,7 +219,7 @@ void provisionFromBranchParallelStage(String jobName, Map envsMap, CreateNamespa
         String envName = "${namespaceCreateParams.getClusterName()}-${namespaceCreateParams.getNamespaceName()}"
 
         branches[envName] = { ->
-          subJobsMap[id] = folioTriggerJob.createNamespaceFromBranch(jobName, namespaceCreateParams, false)
+          subJobsMap[id] = folioTriggerJob.createNamespaceFromBranch(jobName, namespaceCreateParams, false, true)
 
           if (subJobsMap[id]?.getResult() == 'FAILURE') {
             throw new Exception(subJobsMap[id]?.getDescription() as String)

--- a/pipelines/folioRancher/folioQualityGates/Jenkinsfile
+++ b/pipelines/folioRancher/folioQualityGates/Jenkinsfile
@@ -219,7 +219,7 @@ void provisionFromBranchParallelStage(String jobName, Map envsMap, CreateNamespa
         String envName = "${namespaceCreateParams.getClusterName()}-${namespaceCreateParams.getNamespaceName()}"
 
         branches[envName] = { ->
-          subJobsMap[id] = folioTriggerJob.createNamespaceFromBranch(jobName, namespaceCreateParams)
+          subJobsMap[id] = folioTriggerJob.createNamespaceFromBranch(jobName, namespaceCreateParams, false)
 
           if (subJobsMap[id]?.getResult() == 'FAILURE') {
             throw new Exception(subJobsMap[id]?.getDescription() as String)

--- a/pipelines/folioRancher/folioQualityGates/Jenkinsfile
+++ b/pipelines/folioRancher/folioQualityGates/Jenkinsfile
@@ -186,6 +186,9 @@ ansiColor('xterm') {
       }
     } catch (e) {
       logger.error("Caught exception: ${e}")
+
+      currentBuild.result = 'FAILURE'
+      error(e.getMessage())
     } finally {
       if (!autoCanceled) {
         destroyParallelStage(deleteNamespaceJob, envsMap, namespaceBaseParams, globalSlackChannel)

--- a/pipelines/folioRancher/folioQualityGates/Jenkinsfile
+++ b/pipelines/folioRancher/folioQualityGates/Jenkinsfile
@@ -186,9 +186,6 @@ ansiColor('xterm') {
       }
     } catch (e) {
       logger.error("Caught exception: ${e}")
-
-      currentBuild.result = 'FAILURE'
-      error(e.getMessage())
     } finally {
       if (!autoCanceled) {
         destroyParallelStage(deleteNamespaceJob, envsMap, namespaceBaseParams, globalSlackChannel)

--- a/vars/folioTriggerJob.groovy
+++ b/vars/folioTriggerJob.groovy
@@ -14,8 +14,8 @@ def deleteNamespace(String jobName, CreateNamespaceParameters namespaceParams) {
   return jobResult
 }
 
-def createNamespaceFromBranch(String jobName, CreateNamespaceParameters namespaceParams, boolean propagateJobRunStatus = true) {
-  def jobResult = build job: jobName, wait: true, propagate: propagateJobRunStatus,
+def createNamespaceFromBranch(String jobName, CreateNamespaceParameters namespaceParams, boolean propagateJobRunStatus = true, boolean waitJobComplete = true) {
+  def jobResult = build job: jobName, wait: waitJobComplete, propagate: propagateJobRunStatus,
     parameters: [
       string(name: 'CLUSTER', value: namespaceParams.getClusterName()),
       string(name: 'NAMESPACE', value: namespaceParams.getNamespaceName()),

--- a/vars/folioTriggerJob.groovy
+++ b/vars/folioTriggerJob.groovy
@@ -14,7 +14,7 @@ def deleteNamespace(String jobName, CreateNamespaceParameters namespaceParams) {
   return jobResult
 }
 
-def createNamespaceFromBranch(String jobName, CreateNamespaceParameters namespaceParams, Boolean propagateJobRunStatus = true) {
+def createNamespaceFromBranch(String jobName, CreateNamespaceParameters namespaceParams, boolean propagateJobRunStatus = true) {
   def jobResult = build job: jobName, wait: true, propagate: propagateJobRunStatus,
     parameters: [
       string(name: 'CLUSTER', value: namespaceParams.getClusterName()),

--- a/vars/folioTriggerJob.groovy
+++ b/vars/folioTriggerJob.groovy
@@ -14,8 +14,8 @@ def deleteNamespace(String jobName, CreateNamespaceParameters namespaceParams) {
   return jobResult
 }
 
-def createNamespaceFromBranch(String jobName, CreateNamespaceParameters namespaceParams) {
-  def jobResult = build job: jobName, wait: true, propagate: false,
+def createNamespaceFromBranch(String jobName, CreateNamespaceParameters namespaceParams, Boolean propagateJobRunStatus = true) {
+  def jobResult = build job: jobName, wait: true, propagate: propagateJobRunStatus,
     parameters: [
       string(name: 'CLUSTER', value: namespaceParams.getClusterName()),
       string(name: 'NAMESPACE', value: namespaceParams.getNamespaceName()),


### PR DESCRIPTION
Fix: sub job Create Namespace from Branch doesn't propagate failed status to its root calling job.