### PR TITLE
RANCHER-2160. Add another module descriptor source to allow utilizing custom module descriptors. Switch to correct Jenkins maven usage.

### DIFF
--- a/vars/common.groovy
+++ b/vars/common.groovy
@@ -83,6 +83,9 @@ String selectJavaBasedOnAgent(String agent_name) {
     case ~/^.*21.*$/:
       return 'openjdk-21-jenkins-slave-all'
       break
+    case ~/^rancher.*$/:
+      return 'openjdk-21-jenkins-slave-all'
+      break
     default:
       new Logger(this, 'common').error('Can not detect required Java version')
   }

--- a/vars/folioEurekaAppGenerator.groovy
+++ b/vars/folioEurekaAppGenerator.groovy
@@ -23,7 +23,7 @@ def generateApplicationDescriptor(String appName, Map<String, String> moduleList
         sh """
               mvn clean compile -U -e \
               -DbuildNumber=${BUILD_NUMBER} \
-              -Dregistries='${org.folio.rest_v2.Constants.OKAPI_REGISTRY},s3::eureka-application-registry::descriptors' \
+              -Dregistries='okapi::${org.folio.rest_v2.Constants.OKAPI_REGISTRY},s3::eureka-application-registry::descriptors' \
               -DawsRegion=us-west-2
             """.stripIndent()
       }


### PR DESCRIPTION
Tested:
https://jenkins-aws.indexdata.com/job/folioRancher/job/tmpFolderForDraftPipelines/job/VasylA/job/createNamespaceFromBranch-Eureka-2160-test/75/console