### PR TITLE
RANCHER-2195 Increase workers number for executing e2e tests in Quality Gates pipeline

### DIFF
--- a/pipelines/folioRancher/folioScheduledTesting/folioQualityGates/Jenkinsfile
+++ b/pipelines/folioRancher/folioScheduledTesting/folioQualityGates/Jenkinsfile
@@ -131,7 +131,7 @@ ansiColor('xterm') {
         cypressParameters.setTenant(new OkapiTenant('diku')
           .withAdminUser(new OkapiUser('diku_admin', 'admin')))
         cypressParameters.setExecParameters('--env grepTags="shiftLeft"')
-        cypressParameters.setNumberOfWorkers(4)
+        cypressParameters.setNumberOfWorkers(5)
         cypressParameters.setTimeout('180')
 
         cypressTestsExecutionSummary = folioCypressFlow.call(cypressParameters.getCiBuildId(), [cypressParameters], false, true, 'ci')

--- a/pipelines/folioRancher/folioTestingTools/runCypressTests/Jenkinsfile
+++ b/pipelines/folioRancher/folioTestingTools/runCypressTests/Jenkinsfile
@@ -29,7 +29,7 @@ properties([
     booleanParam(name: 'PREPARE', defaultValue: false, description: 'Set to true, to run prepare stage'),
     booleanParam(name: 'REPORT_PORTAL_USE', defaultValue: false, description: 'Set to true, to send tests results to Report Portal'),
     choice(name: 'REPORT_PORTAL_RUN_TYPE', choices: ["day", "night", "week", "evrk"], description: 'Parameter for Report portal filtering'),
-    folioParameters.runSanityCheck(),
+    folioParameters.runSanityCheck(false),
     folioParameters.refreshParameters()])
 ])
 


### PR DESCRIPTION
Additional: disable sanity check by default for the runCypressTests job