### PR TITLE
RANCHER-2395 Include Finc app in Eureka snapshot env

### DIFF
--- a/resources/helm/development.yaml
+++ b/resources/helm/development.yaml
@@ -1474,6 +1474,37 @@ mod-feesfines:
   pdb:
     enabled: true
     maxUnavailable: 1
+mod-finc-config:
+  extraEnvVars:
+  - name: EZB_DOWNLOAD_URL
+    value: https://ezb-api.ur.de/ezb/export/licenselist_html.php?pack=0&bibid=%s&lang=de&output_style=kbart&todo_license=ALkbart
+  integrations:
+    okapi:
+      enabled: true
+      existingSecret: okapi-credentials
+    db:
+      enabled: true
+      existingSecret: db-credentials
+  replicaCount: 1
+  resources:
+    limits:
+      memory: 384Mi
+    requests:
+      memory: 256Mi
+  extraJavaOpts:
+  - -XX:MaxRAMPercentage=85.0
+  startupProbe:
+    httpGet:
+      path: /admin/health
+      port: 8081
+    initialDelaySeconds: 60
+    periodSeconds: 20
+    timeoutSeconds: 5
+    successThreshold: 1
+    failureThreshold: 30
+  pdb:
+    enabled: true
+    maxUnavailable: 1
 mod-finance:
   extraEnvVars: []
   integrations: {}

--- a/resources/helm/performance.yaml
+++ b/resources/helm/performance.yaml
@@ -1891,6 +1891,52 @@ mod-feesfines:
           memory: 400Mi
         requests:
           memory: 290Mi
+mod-finc-config:
+  extraEnvVars:
+  - name: EZB_DOWNLOAD_URL
+    value: https://ezb-api.ur.de/ezb/export/licenselist_html.php?pack=0&bibid=%s&lang=de&output_style=kbart&todo_license=ALkbart
+  integrations:
+    okapi:
+      enabled: true
+      existingSecret: okapi-credentials
+    db:
+      enabled: true
+      existingSecret: db-credentials
+  replicaCount: 1
+  resources:
+    limits:
+      memory: 384Mi
+    requests:
+      memory: 256Mi
+  autoscaling:
+    enabled: true
+    minReplicas: 1
+    maxReplicas: 2
+    targetMemoryUtilizationPercentage: 75
+  extraJavaOpts:
+  - -XX:MaxRAMPercentage=85.0
+  startupProbe:
+    httpGet:
+      path: /admin/health
+      port: 8081
+    initialDelaySeconds: 60
+    periodSeconds: 20
+    timeoutSeconds: 5
+    successThreshold: 1
+    failureThreshold: 30
+  pdb:
+    enabled: true
+    maxUnavailable: 1
+  sidecarContainers:
+    eureka:
+      extraEnvVars:
+        - name: JAVA_OPTS
+          value: "-Dquarkus.log.level=DEBUG -Dquarkus.http.host=0.0.0.0 -Djava.util.logging.manager=org.jboss.logmanager.LogManager -XX:+UseZGC -Xms160m -Xmx160m -Dquarkus.log.category.'org.apache.kafka'.level=DEBUG"
+      resources:
+        limits:
+          memory: 400Mi
+        requests:
+          memory: 290Mi
 mod-finance:
   extraEnvVars: []
   integrations: {}

--- a/resources/helm/testing.yaml
+++ b/resources/helm/testing.yaml
@@ -1897,6 +1897,52 @@ mod-feesfines:
           memory: 400Mi
         requests:
           memory: 290Mi
+mod-finc-config:
+  extraEnvVars:
+  - name: EZB_DOWNLOAD_URL
+    value: https://ezb-api.ur.de/ezb/export/licenselist_html.php?pack=0&bibid=%s&lang=de&output_style=kbart&todo_license=ALkbart
+  integrations:
+    okapi:
+      enabled: true
+      existingSecret: okapi-credentials
+    db:
+      enabled: true
+      existingSecret: db-credentials
+  replicaCount: 1
+  resources:
+    limits:
+      memory: 384Mi
+    requests:
+      memory: 256Mi
+  autoscaling:
+    enabled: true
+    minReplicas: 1
+    maxReplicas: 2
+    targetMemoryUtilizationPercentage: 75
+  extraJavaOpts:
+  - -XX:MaxRAMPercentage=85.0
+  startupProbe:
+    httpGet:
+      path: /admin/health
+      port: 8081
+    initialDelaySeconds: 60
+    periodSeconds: 20
+    timeoutSeconds: 5
+    successThreshold: 1
+    failureThreshold: 30
+  pdb:
+    enabled: true
+    maxUnavailable: 1
+  sidecarContainers:
+    eureka:
+      extraEnvVars:
+        - name: JAVA_OPTS
+          value: "-Dquarkus.log.level=DEBUG -Dquarkus.http.host=0.0.0.0 -Djava.util.logging.manager=org.jboss.logmanager.LogManager -XX:+UseZGC -Xms160m -Xmx160m -Dquarkus.log.category.'org.apache.kafka'.level=DEBUG"
+      resources:
+        limits:
+          memory: 400Mi
+        requests:
+          memory: 290Mi
 mod-finance:
   extraEnvVars: []
   integrations: {}


### PR DESCRIPTION
Template renders:
```
install.go:224: 2025-06-19 12:22:41.80541 +0300 EEST m=+0.116919835 [debug] Original chart version: ""
install.go:241: 2025-06-19 12:22:41.806533 +0300 EEST m=+0.118042460 [debug] CHART PATH: /Users/Oleksandr_Haimanov/Workspace/git/folio/folio-org/folio-helm-v2/charts/mod-finc-config

---
# Source: mod-finc-config/templates/application.yaml
---
apiVersion: policy/v1
kind: PodDisruptionBudget
metadata:
  name: mod-finc-config
  labels:
    helm.sh/chart: mod-finc-config-6.1.0
    app.kubernetes.io/name: mod-finc-config
    app.kubernetes.io/instance: mod-finc-config
    app.kubernetes.io/version: "6.1.0"
    app.kubernetes.io/managed-by: Helm
spec:
  maxUnavailable: 1
  selector:
    matchLabels:
      app.kubernetes.io/name: mod-finc-config
      app.kubernetes.io/instance: mod-finc-config
---
# Source: mod-finc-config/templates/application.yaml
apiVersion: v1
kind: ServiceAccount
metadata:
  name: mod-finc-config
  labels:
    helm.sh/chart: mod-finc-config-6.1.0
    app.kubernetes.io/name: mod-finc-config
    app.kubernetes.io/instance: mod-finc-config
    app.kubernetes.io/version: "6.1.0"
    app.kubernetes.io/managed-by: Helm
---
# Source: mod-finc-config/templates/application.yaml
apiVersion: v1
data:
  log4j2.xml: ""
kind: ConfigMap
metadata:
  labels:
    app.kubernetes.io/instance: mod-finc-config
    app.kubernetes.io/managed-by: Helm
    app.kubernetes.io/name: mod-finc-config
    app.kubernetes.io/version: 6.1.0
    helm.sh/chart: mod-finc-config-6.1.0
  name: mod-finc-config-log4j
---
# Source: mod-finc-config/templates/application.yaml
apiVersion: v1
kind: Service
metadata:
  name: mod-finc-config
  labels:
    helm.sh/chart: mod-finc-config-6.1.0
    app.kubernetes.io/name: mod-finc-config
    app.kubernetes.io/instance: mod-finc-config
    app.kubernetes.io/version: "6.1.0"
    app.kubernetes.io/managed-by: Helm
  annotations:
    {}
spec:
  type: ClusterIP
  ports:
    - name: http
      protocol: TCP
      port: 80
      targetPort: http
    - name: sidecar
      protocol: TCP
      port: 8082
      targetPort: 8082
  selector:
    app.kubernetes.io/name: mod-finc-config
    app.kubernetes.io/instance: mod-finc-config
---
# Source: mod-finc-config/templates/application.yaml
apiVersion: apps/v1
kind: Deployment
metadata:
  name: mod-finc-config
  labels:
    helm.sh/chart: mod-finc-config-6.1.0
    app.kubernetes.io/name: mod-finc-config
    app.kubernetes.io/instance: mod-finc-config
    app.kubernetes.io/version: "6.1.0"
    app.kubernetes.io/managed-by: Helm
spec:
  strategy:
    type: Recreate
  selector:
    matchLabels: 
      app.kubernetes.io/name: mod-finc-config
      app.kubernetes.io/instance: mod-finc-config
  template:
    metadata:
      labels: 
        app.kubernetes.io/name: mod-finc-config
        app.kubernetes.io/instance: mod-finc-config
    spec:
      serviceAccountName: mod-finc-config
      containers:
        - name: mod-finc-config
          image: "folioorg/mod-finc-config:6.1.0"
          imagePullPolicy: IfNotPresent
          env:
            - name: EZB_DOWNLOAD_URL
              value: https://ezb-api.ur.de/ezb/export/licenselist_html.php?pack=0&bibid=%s&lang=de&output_style=kbart&todo_license=ALkbart
            - name: IS_EUREKA
              value: "true"
            - name: JAVA_OPTIONS
              value: "-XX:MaxRAMPercentage=85.0 -Dlog4j.configurationFile=/etc/log4j2.xml/log4j2.xml"
          envFrom:
            - secretRef:
                name: db-credentials
            - secretRef:
                name: eureka-common
            - secretRef:
                name: okapi-credentials
          resources: 
            limits:
              memory: 384Mi
            requests:
              memory: 256Mi
          startupProbe: 
            failureThreshold: 30
            httpGet:
              path: /admin/health
              port: 8081
            initialDelaySeconds: 60
            periodSeconds: 20
            successThreshold: 1
            timeoutSeconds: 5
          ports:
            - name: http
              containerPort: 8081
              protocol: TCP
            - name: sidecar
              containerPort: 8082
              protocol: TCP
          volumeMounts:            
            - name: log4j
              mountPath: /etc/log4j2.xml/log4j2.xml
              subPath: log4j2.xml
        - name: sidecar
          image: "folioorg/folio-module-sidecar:latest"
          imagePullPolicy: IfNotPresent
          env:
          - name: AM_CLIENT_URL
            value: "http://mgr-applications"
          - name: QUARKUS_HTTP_PORT
            value: "8082"
          - name: QUARKUS_REST_CLIENT_READ_TIMEOUT
            value: "180000"
          - name: QUARKUS_REST_CLIENT_CONNECT_TIMEOUT
            value: "180000"
          - name: QUARKUS_REST_CLIENT_SEND_TIMEOUT
            value: "180000"
          - name: QUARKUS_HTTP_LIMITS_MAX_BODY_SIZE
            value: "10240K"
          - name: TE_CLIENT_URL
            value: "http://mgr-tenant-entitlements"
          - name: TM_CLIENT_URL
            value: "http://mgr-tenants"
          - name: MODULE_URL
            value: "http://localhost:8081"
          - name: MODULE_NAME
            value: "mod-finc-config"
          - name: MODULE_VERSION
            value: ""
          - name: SIDECAR_FORWARD_UNKNOWN_REQUESTS
            value: "true"
          - name: SIDECAR_URL
            value: "http://localhost:8082"
          - name: SIDECAR
            value: "true"
          - name: REQUEST_TIMEOUT
            value: "604800000"
          - name: KC_LOGIN_CLIENT_SUFFIX
            value: "-application"
          - name: KC_URI_VALIDATION_ENABLED
            value: "false"
          - name: ALLOW_CROSS_TENANT_REQUESTS
            value: "true"
          - name: QUARKUS_HTTP_LIMITS_MAX_INITIAL_LINE_LENGTH
            value: "8192"
          - name: JAVA_OPTS
            value: "-Dquarkus.log.level=INFO -Dquarkus.http.host=0.0.0.0 -Djava.util.logging.manager=org.jboss.logmanager.LogManager -XX:+UseZGC -Xms64m -Xmx64m -Dquarkus.log.category.'org.apache.kafka'.level=INFO"
          - name: SC_LOG_LEVEL
            value: "INFO"
          - name: ROOT_LOG_LEVEL
            value: "INFO"
          - name: SECRET_STORE_TYPE
            valueFrom:
              secretKeyRef:
                name: eureka-common
                key: SECRET_STORE_TYPE
          - name: SECRET_STORE_AWS_SSM_REGION
            valueFrom:
              secretKeyRef:
                name: eureka-common
                key: SECRET_STORE_AWS_SSM_REGION
          - name: ENV
            valueFrom:
              secretKeyRef:
                name: db-credentials
                key: ENV
          - name: SIDECAR_FORWARD_UNKNOWN_REQUESTS_DESTINATION
            valueFrom:
              secretKeyRef:
                name: eureka-common
                key: SIDECAR_FORWARD_UNKNOWN_REQUESTS_DESTINATION
          - name: KAFKA_HOST
            valueFrom:
              secretKeyRef:
                name: kafka-credentials
                key: KAFKA_HOST
          - name: KAFKA_PORT
            valueFrom:
              secretKeyRef:
                name: kafka-credentials
                key: KAFKA_PORT
          - name: MOD_USERS_KEYCLOAK_URL
            valueFrom:
              secretKeyRef:
                name: eureka-common
                key: MOD_USERS_KEYCLOAK_URL
          - name: MOD_USERS_BL
            valueFrom:
              secretKeyRef:
                name: eureka-common
                key: MOD_USERS_BL
          - name: KC_URL
            valueFrom:
              secretKeyRef:
                name: eureka-common
                key: KC_URL
          - name: JAVA_OPTS
            value: -Dquarkus.log.level=DEBUG -Dquarkus.http.host=0.0.0.0 -Djava.util.logging.manager=org.jboss.logmanager.LogManager -XX:+UseZGC -Xms160m -Xmx160m -Dquarkus.log.category.'org.apache.kafka'.level=DEBUG
          resources: 
            limits:
              memory: 400Mi
            requests:
              memory: 290Mi
      volumes:        
        - name: log4j
          configMap:
            name: mod-finc-config-log4j
            defaultMode: 0755
---
# Source: mod-finc-config/templates/application.yaml
apiVersion: autoscaling/v2
kind: HorizontalPodAutoscaler
metadata:
  name: mod-finc-config
  labels:
    helm.sh/chart: mod-finc-config-6.1.0
    app.kubernetes.io/name: mod-finc-config
    app.kubernetes.io/instance: mod-finc-config
    app.kubernetes.io/version: "6.1.0"
    app.kubernetes.io/managed-by: Helm
spec:
  scaleTargetRef:
    apiVersion: apps/v1
    kind: Deployment
    name: mod-finc-config
  minReplicas: 1
  maxReplicas: 2
  metrics:
    - type: Resource
      resource:
        name: memory
        target:
          type: Utilization
          averageUtilization: 75
```