### PR TITLE
RANCHER-2472. Remove `extraEnvVarsSecrets` references for `mod-finance-storage` across all environments.

### DIFF
--- a/resources/helm/development.yaml
+++ b/resources/helm/development.yaml
@@ -1529,8 +1529,6 @@ mod-finance:
     enabled: true
     maxUnavailable: 1
 mod-finance-storage:
-  extraEnvVarsSecrets:
-    - eureka-common
   extraEnvVars: []
   integrations:
     db:

--- a/resources/helm/performance.yaml
+++ b/resources/helm/performance.yaml
@@ -1976,8 +1976,6 @@ mod-finance:
         requests:
           memory: 290Mi
 mod-finance-storage:
-  extraEnvVarsSecrets:
-    - eureka-common
   extraEnvVars: []
   integrations:
     db:

--- a/resources/helm/testing.yaml
+++ b/resources/helm/testing.yaml
@@ -1982,8 +1982,6 @@ mod-finance:
         requests:
           memory: 290Mi
 mod-finance-storage:
-  extraEnvVarsSecrets:
-    - eureka-common
   extraEnvVars: []
   integrations:
     db:


### PR DESCRIPTION
Tested:
Eureka: https://jenkins.ci.folio.org/job/tmpFolderForDraftPipelines/job/Avramenko/job/createNamespaceFromBranch-2472-test/62/console

OKAPI: https://jenkins.ci.folio.org/job/tmpFolderForDraftPipelines/job/Avramenko/job/createNamespaceFromBranch-2472-test/63/console