### PR TITLE
RANCHER-2547: Add app-serials-management to application composition

### DIFF
--- a/src/org/folio/rest_v2/Constants.groovy
+++ b/src/org/folio/rest_v2/Constants.groovy
@@ -326,6 +326,14 @@ class Constants {
       , core: false
       , byDefault: true
       , dependsOn: ["app-platform-minimal"]
+    ],
+    [
+      name: "app-serials-management"
+      , branch: "snapshot"
+      , consortia: false
+      , core: false
+      , byDefault: true
+      , dependsOn: ["app-platform-minimal"]
     ]
   ]
 


### PR DESCRIPTION
Tested:
https://jenkins.ci.folio.org/job/tmpFolderForDraftPipelines/job/Avramenko/job/createNamespaceFromBranch-2547/15/console