### PR TITLE
RANCHER-2560. Fix Application Descriptor Update for Release Versions

### DIFF
--- a/src/org/folio/rest_v2/eureka/Eureka.groovy
+++ b/src/org/folio/rest_v2/eureka/Eureka.groovy
@@ -306,10 +306,9 @@ class Eureka extends Base {
     Map<String, String> updatedAppInfoMap = [:]
 
     appWithDescriptors.each { app ->
+      String newBuildNumber = app.build ? (app.build.toInteger() + 1).toString() : ""
 
-      String incrementalNumber = app.build.toInteger() + 1
-
-      Map updatedAppDescriptor = getUpdatedApplicationDescriptor(app.descriptor, module, incrementalNumber)
+      Map updatedAppDescriptor = getUpdatedApplicationDescriptor(app.descriptor, module, newBuildNumber)
 
       Applications.get(kong).registerApplication(updatedAppDescriptor)
 
@@ -323,14 +322,26 @@ class Eureka extends Base {
    * Get Updated Application Descriptor with new Module Version
    * @param appDescriptor Current Application Descriptor as a Map
    * @param module Module object to be updated
-   * @param buildNumber Build Number for new Application Version
+   * @param buildNumber Build Number for snapshot versions
    * @return Updated Application Descriptor as a Map
    */
-  //TODO: Refactoring needed
-  Map getUpdatedApplicationDescriptor(Map appDescriptor, EurekaModule module, String buildNumber) {
-    // Update Application Descriptor with incremented Application Version
+  Map getUpdatedApplicationDescriptor(Map appDescriptor, EurekaModule module, String buildNumber = "") {
     String currentAppVersion = appDescriptor.version
-    String newAppVersion = currentAppVersion.replaceFirst(/SNAPSHOT\.\d+/, "SNAPSHOT.${buildNumber}")
+    String newAppVersion
+
+    if (currentAppVersion ==~ /^\d+\.\d+\.\d+-SNAPSHOT\.\d+$/) {
+      newAppVersion = currentAppVersion.replaceFirst(/SNAPSHOT\.\d+/, "SNAPSHOT.${buildNumber}")
+      logger.info("Updated snapshot application version from ${currentAppVersion} to ${newAppVersion}")
+    } else if (currentAppVersion ==~ /^\d+\.\d+\.\d+$/) {
+      def versionParts = currentAppVersion.tokenize('.')
+      int major = versionParts[0] as int
+      int minor = versionParts[1] as int
+      int patch = versionParts[2] as int
+      newAppVersion = "${major}.${minor}.${patch + 1}"
+      logger.info("Updated release application version from ${currentAppVersion} to ${newAppVersion} (bumped patch)")
+    } else {
+      throw new IllegalArgumentException("Unsupported application version format: ${currentAppVersion}")
+    }
 
     appDescriptor.version = newAppVersion
     appDescriptor.id = "${appDescriptor.name}-${newAppVersion}"

--- a/vars/folioEurekaAppGenerator.groovy
+++ b/vars/folioEurekaAppGenerator.groovy
@@ -121,8 +121,7 @@ Map generateFromRepository(String repoName, FolioInstallJson moduleList, String 
       writeJSON file: repoName + ".template.json", json: updatedTemplate
     }
 
-    return _generate(repoName, debug,"org.folio:folio-application-generator:generateFromJson"
-      , "-Dfolio-application-generator.version=1.1.0")
+    return _generate(repoName, debug)
   }
 }
 


### PR DESCRIPTION
# Fix Application Descriptor Update for Release Versions

## Summary

Fixes deployment failures when updating application descriptors for release versions (e.g., `app-edge-complete-2.1.0`) in Sunflower Rancher environments. The pipeline was failing with `NumberFormatException` because it assumed all applications have snapshot-style build numbers.

## Problem

When deploying modules to Sunflower (which uses release versions), the pipeline failed with:
```
java.lang.NumberFormatException: For input string: ""
```

This occurred because:
- Release versions like `2.1.0` don't have build numbers
- The code attempted `app.build.toInteger()` on an empty string

## Changes

### 1. Enhanced Version Handling in `Eureka.groovy`

#### `updateAppDescriptorFlow` (line 309)
- Added null-safe build number handling
- Safely converts build numbers: `app.build ? (app.build.toInteger() + 1).toString() : ""`

#### `getUpdatedApplicationDescriptor` (lines 330-346)
- **Snapshot versions** (`2.1.0-SNAPSHOT.123`): Increments build number (existing behavior)
- **Release versions** (`2.1.0`): Bumps patch version (`2.1.0` → `2.1.1`)
- Added version format validation with `IllegalArgumentException`
- Added default parameter `buildNumber = ""` for backward compatibility

### 2. Eureka App Generator Version Fix

#### `folioEurekaAppGenerator.groovy`
- Removed hardcoded version limitation (`1.1.0`)
- Now uses version from `pom.xml` as intended

## Testing

✅ Successfully tested with both version types:

**Module deployment:** [Build #3713](https://jenkins.ci.folio.org/job/folioDevTools/job/moduleDeployment/job/deployModuleFromFeatureBranchEureka/3713/console)

**Namespace creation:** [Build #69](https://jenkins.ci.folio.org/job/tmpFolderForDraftPipelines/job/Avramenko/job/createNamespaceFromBranch-2560-test/69/console)

## Impact

- ✅ Enables module deployment to Sunflower environments with release versions
- ✅ Maintains backward compatibility with snapshot versions
- ✅ Resolves `edge-orders` deployment failures caused by app composition changes