### PR TITLE
RANCHER-2529. Entitlement Approach Selection

### DIFF
--- a/pipelines/folioRancher/folioNamespaceTools/manageNamespace/createNamespaceFromBranch/Jenkinsfile
+++ b/pipelines/folioRancher/folioNamespaceTools/manageNamespace/createNamespaceFromBranch/Jenkinsfile
@@ -7,6 +7,7 @@ import org.folio.models.RancherNamespace
 import org.folio.models.parameters.CreateNamespaceParameters
 import org.folio.models.parameters.CypressTestsParameters
 import org.folio.Constants
+import org.folio.rest_v2.EntitlementApproach
 import org.folio.rest_v2.PlatformType
 import org.jenkinsci.plugins.workflow.libs.Library
 
@@ -26,7 +27,7 @@ properties([
     booleanParam(name: 'SC_NATIVE', defaultValue: true, description: '(Optional) Set false to use Java based SC image'),
     folioParameters.groupParameters('Environment features'
       , ['LOAD_REFERENCE', 'LOAD_SAMPLE', 'BUILD_UI', 'CONSORTIA', 'CONSORTIA_SINGLE_UI', 'CONSORTIA_EXTRA', 'LINKED_DATA', 'MARC_MIGRATIONS', 'RTAC_CACHE',  'EDGE_LOCATE'
-         , 'SPLIT_FILES', 'RW_SPLIT', 'ECS_CCL', 'GREENMAIL', 'MOCK_SERVER', 'RTR', 'DATASET', 'TYPE'
+         , 'SPLIT_FILES', 'RW_SPLIT', 'ECS_CCL', 'GREENMAIL', 'MOCK_SERVER', 'RTR', 'DATASET', 'TYPE', 'ENTITLEMENT_APPROACH'
          , 'HAS_SECURE_TENANT', 'SECURE_TENANT', 'FOLIO_KEYCLOAK_VERSION', 'FOLIO_KONG_VERSION'
     ]),
     folioParameters.loadReference(),
@@ -49,6 +50,7 @@ properties([
     booleanParam(name: 'RTR', defaultValue: false, description: '(Optional) Set true to enable RTR'),
     booleanParam(name: 'DATASET', defaultValue: false, description: '(Optional) Set true to build BF like environment'),
     choice(name: 'TYPE', choices: ['full', 'terraform', 'update'], description: '(Required) Set action TYPE to perform'),
+    choice(name: 'ENTITLEMENT_APPROACH', choices: ['STATE', 'CREATE'], description: '(Optional) Entitlement method: STATE = PUT /entitlements/state (declarative), CREATE = POST /entitlements (procedural)'),
     string(name: 'DB_BACKUP_NAME', defaultValue: Constants.BUGFEST_SNAPSHOT_NAME, description: '(Optional) Set name of the DB backup to restore'),
     string(name: 'FOLIO_KEYCLOAK_VERSION', defaultValue: 'latest', description: '(Optional) Set FOLIO Keycloak tag, example: 21.0.1-SNAPSHOT.f959523'),
     string(name: 'FOLIO_KONG_VERSION', defaultValue: 'latest', description: '(Optional) Set FOLIO Kong tag, example: 3.10.0-SNAPSHOT.f959523'),
@@ -64,7 +66,7 @@ properties([
     , folioParameters.hideParameters(
     [
       'EUREKA': ['OKAPI_VERSION', 'EDGE_LOCATE', 'RTAC_CACHE', 'FOLIO_BRANCH', 'LINKED_DATA', 'MARC_MIGRATIONS', 'FOLIO_KEYCLOAK_VERSION', 'FOLIO_KONG_VERSION'],
-      'OKAPI' : ['PLATFORM_BRANCH', 'APPLICATIONS', 'SC_NATIVE']
+      'OKAPI' : ['PLATFORM_BRANCH', 'APPLICATIONS', 'SC_NATIVE', 'ENTITLEMENT_APPROACH']
     ]
     , 'PLATFORM')
     , folioParameters.hideParameters(
@@ -127,6 +129,7 @@ CreateNamespaceParameters namespaceParams = new CreateNamespaceParameters.Builde
   .dataset(params.DATASET)
   .type(params.TYPE)
   .scNative(params.SC_NATIVE)
+  .entitlementApproach(EntitlementApproach.valueOf(params.ENTITLEMENT_APPROACH))
   .build()
 
 if (params.CONSORTIA) {

--- a/src/org/folio/models/parameters/CreateNamespaceParameters.groovy
+++ b/src/org/folio/models/parameters/CreateNamespaceParameters.groovy
@@ -1,6 +1,7 @@
 package org.folio.models.parameters
 
 import com.cloudbees.groovy.cps.NonCPS
+import org.folio.rest_v2.EntitlementApproach
 import org.folio.rest_v2.PlatformType
 
 /**
@@ -56,6 +57,8 @@ class CreateNamespaceParameters implements Cloneable {
   boolean dataset = false
 
   boolean scNative = false
+
+  EntitlementApproach entitlementApproach = EntitlementApproach.STATE
 
   String dmSnapshot
 
@@ -534,6 +537,11 @@ class CreateNamespaceParameters implements Cloneable {
      */
     Builder scNative(boolean scNative) {
       parameters.scNative = scNative
+      return this
+    }
+
+    Builder entitlementApproach(EntitlementApproach entitlementApproach) {
+      parameters.entitlementApproach = entitlementApproach
       return this
     }
 

--- a/src/org/folio/rest_v2/EntitlementApproach.groovy
+++ b/src/org/folio/rest_v2/EntitlementApproach.groovy
@@ -1,0 +1,5 @@
+package org.folio.rest_v2
+
+enum EntitlementApproach {
+  STATE, CREATE
+}

--- a/src/org/folio/rest_v2/eureka/Eureka.groovy
+++ b/src/org/folio/rest_v2/eureka/Eureka.groovy
@@ -7,6 +7,7 @@ import org.folio.models.application.Application
 import org.folio.models.application.ApplicationList
 import org.folio.models.module.EurekaModule
 import org.folio.models.module.FolioModule
+import org.folio.rest_v2.EntitlementApproach
 import org.folio.rest_v2.eureka.kong.*
 
 class Eureka extends Base {
@@ -29,7 +30,8 @@ class Eureka extends Base {
     return this
   }
 
-  Eureka createTenantFlow(EurekaTenant tenant, String cluster, String namespace, boolean migrate = false) {
+  Eureka createTenantFlow(EurekaTenant tenant, String cluster, String namespace,
+                           boolean migrate = false, EntitlementApproach entitlementApproach = EntitlementApproach.STATE) {
     EurekaTenant createdTenant = Tenants.get(kong).createTenant(tenant)
 
     tenant.withUUID(createdTenant.getUuid())
@@ -44,10 +46,17 @@ class Eureka extends Base {
 
     kong.keycloak.defineTTL(tenant.tenantId, 600)
 
-    Tenants.get(kong).enableApplications(
-      tenant,
-      tenant.applications.collect { it.id }
-    )
+    if (entitlementApproach == EntitlementApproach.CREATE) {
+      Tenants.get(kong).enableApplications(
+        tenant,
+        tenant.applications.collect { it.id }
+      )
+    } else {
+      Tenants.get(kong).enableDesiredApplications(
+        tenant,
+        tenant.applications.collect { it.id }
+      )
+    }
 
     context.folioTools.stsKafkaLag(cluster, namespace, tenant.tenantId)
 
@@ -213,9 +222,10 @@ class Eureka extends Base {
   }
 
   Eureka initializeFromScratch(Map<String, EurekaTenant> tenants, String cluster, String namespace
-                               , boolean enableConsortia, boolean migrate = false) {
+                               , boolean enableConsortia, boolean migrate = false
+                               , EntitlementApproach entitlementApproach = EntitlementApproach.STATE) {
     tenants.each { tenantId, tenant ->
-      createTenantFlow(tenant, cluster, namespace, migrate)
+      createTenantFlow(tenant, cluster, namespace, migrate, entitlementApproach)
     }
 
     if (enableConsortia)

--- a/src/org/folio/rest_v2/eureka/Eureka.groovy
+++ b/src/org/folio/rest_v2/eureka/Eureka.groovy
@@ -47,9 +47,12 @@ class Eureka extends Base {
     kong.keycloak.defineTTL(tenant.tenantId, 600)
 
     if (entitlementApproach == EntitlementApproach.CREATE) {
+      ApplicationList entitledApps = Tenants.get(kong).getEnabledApplications(tenant)
       Tenants.get(kong).enableApplications(
         tenant,
-        tenant.applications.collect { it.id }
+        tenant.applications
+          .findAll { app -> !entitledApps.any { it.name == app.name } }
+          .collect { it.id }
       )
     } else {
       Tenants.get(kong).enableDesiredApplications(

--- a/src/org/folio/rest_v2/eureka/kong/Tenants.groovy
+++ b/src/org/folio/rest_v2/eureka/kong/Tenants.groovy
@@ -122,8 +122,52 @@ class Tenants extends Kong{
    * @param skipExistence boolean flag to skip error if apps were already enabled.
    * @return Tenants instance.
    */
+  /**
+   * Enable (entitle) applications on tenant using POST /entitlements.
+   *
+   * @param tenant EurekaTenant instance.
+   * @param appIds List of application ids to be enabled.
+   * @param skipExistence boolean flag to skip error if apps were already enabled.
+   * @return Tenants instance.
+   */
   Tenants enableApplications(EurekaTenant tenant, List<String> appIds, boolean skipExistence = false) {
     logger.info("Enable (entitle) applications with ids: ${appIds} on tenant ${tenant.tenantId} with ${tenant.uuid}...")
+    logger.info("TenantParameters: ${tenant.getInstallRequestParams()?.toQueryString() ?: ''}")
+
+    if (!appIds)
+      return this
+
+    Map<String, String> headers = getMasterHttpHeaders(true)
+    Map body = [
+      tenantId    : tenant.uuid,
+      applications: appIds
+    ]
+    List responseCodes = skipExistence ? [201, 400] + (401..599).toList() : []
+
+    try {
+      def response = restClient.post(
+        generateUrl("/entitlements${tenant.getInstallRequestParams()?.toQueryString() ?: ''}"),
+        body,
+        headers,
+        responseCodes
+      )
+      return trackEntitlementFlow(response, tenant, headers)
+    } catch (RequestException ex) {
+      logger.error("Enabling (entitle) applications on tenant ${tenant.tenantId} with ${tenant.uuid} failed with error: ${ex.getMessage()}")
+      return this
+    }
+  }
+
+  /**
+   * Enable (entitle) applications on tenant using PUT /entitlements/state (desired state approach).
+   *
+   * @param tenant EurekaTenant instance.
+   * @param appIds List of application ids to be enabled.
+   * @param skipExistence boolean flag to skip error if apps were already enabled.
+   * @return Tenants instance.
+   */
+  Tenants enableDesiredApplications(EurekaTenant tenant, List<String> appIds, boolean skipExistence = false) {
+    logger.info("Enable desired (entitle) applications with ids: ${appIds} on tenant ${tenant.tenantId} with ${tenant.uuid}...")
     logger.info("TenantParameters: ${tenant.getInstallRequestParams()?.toQueryString() ?: ''}")
 
     if (!appIds)
@@ -143,38 +187,42 @@ class Tenants extends Kong{
         headers,
         responseCodes
       )
-      logger.debug("Response from entitlements: ${response}")
-
-      while (true) {
-        def currentEntitlementStatus = restClient.get(
-          generateUrl("/entitlement-flows/${response.body.flowId}"),
-          headers
-        )
-        logger.debug("Current entitlement flow status: ${currentEntitlementStatus.body.status}")
-        switch (currentEntitlementStatus.body.status) {
-          case 'finished':
-            logger.info("Enabling (entitle) applications on tenant ${tenant.tenantId} with ${tenant.uuid} was finished successfully.")
-            return this
-          case 'cancelled':
-            logger.error("Enabling (entitle) applications on tenant ${tenant.tenantId} with ${tenant.uuid} was cancelled.\n" +
-              "Error message: ${restClient.get(generateUrl("/entitlement-flows/${response.body.flowId}?includeStages=true"), headers)}")
-            return this
-          case 'failed':
-            logger.error("Enabling (entitle) applications on tenant ${tenant.tenantId} with ${tenant.uuid} failed.\n" +
-              "Error message: ${restClient.get(generateUrl("/entitlement-flows/${response.body.flowId}?includeStages=true"), headers)}")
-            return this
-          case 'in_progress':
-            logger.debug("Enabling (entitle) applications on tenant ${tenant.tenantId} with ${tenant.uuid} is still in progress...")
-            sleep(30000)
-            break
-          default:
-            logger.error("Unknown status '${currentEntitlementStatus.body.status}' for enabling (entitle) applications on tenant ${tenant.tenantId} with ${tenant.uuid}.")
-            return this
-        }
-      }
+      return trackEntitlementFlow(response, tenant, headers)
     } catch (RequestException ex) {
-      logger.error("Enabling (entitle) applications on tenant ${tenant.tenantId} with ${tenant.uuid} failed with error: ${ex.getMessage()}")
+      logger.error("Enabling desired (entitle) applications on tenant ${tenant.tenantId} with ${tenant.uuid} failed with error: ${ex.getMessage()}")
       return this
+    }
+  }
+
+  private Tenants trackEntitlementFlow(def response, EurekaTenant tenant, Map<String, String> headers) {
+    logger.debug("Response from entitlements: ${response}")
+
+    while (true) {
+      def currentEntitlementStatus = restClient.get(
+        generateUrl("/entitlement-flows/${response.body.flowId}"),
+        headers
+      )
+      logger.debug("Current entitlement flow status: ${currentEntitlementStatus.body.status}")
+      switch (currentEntitlementStatus.body.status) {
+        case 'finished':
+          logger.info("Enabling (entitle) applications on tenant ${tenant.tenantId} with ${tenant.uuid} was finished successfully.")
+          return this
+        case 'cancelled':
+          logger.error("Enabling (entitle) applications on tenant ${tenant.tenantId} with ${tenant.uuid} was cancelled.\n" +
+            "Error message: ${restClient.get(generateUrl("/entitlement-flows/${response.body.flowId}?includeStages=true"), headers)}")
+          return this
+        case 'failed':
+          logger.error("Enabling (entitle) applications on tenant ${tenant.tenantId} with ${tenant.uuid} failed.\n" +
+            "Error message: ${restClient.get(generateUrl("/entitlement-flows/${response.body.flowId}?includeStages=true"), headers)}")
+          return this
+        case 'in_progress':
+          logger.debug("Enabling (entitle) applications on tenant ${tenant.tenantId} with ${tenant.uuid} is still in progress...")
+          sleep(30000)
+          break
+        default:
+          logger.error("Unknown status '${currentEntitlementStatus.body.status}' for enabling (entitle) applications on tenant ${tenant.tenantId} with ${tenant.uuid}.")
+          return this
+      }
     }
   }
   /**

--- a/vars/folioNamespaceCreateEureka.groovy
+++ b/vars/folioNamespaceCreateEureka.groovy
@@ -371,6 +371,7 @@ void call(CreateNamespaceParameters args) {
             , namespace.getNamespaceName()
             , namespace.getEnableConsortia()
             , false // Set this option true, when users & groups migration is required.
+            , args.entitlementApproach
           )
         }
       }

--- a/vars/folioTriggerJob.groovy
+++ b/vars/folioTriggerJob.groovy
@@ -46,6 +46,7 @@ def createNamespaceFromBranch(String jobName, CreateNamespaceParameters namespac
       string(name: 'OPENSEARCH', value: namespaceParams.getOpensearchType()),
       string(name: 'S3_BUCKET', value: namespaceParams.getS3Type()),
       booleanParam(name: 'SC_NATIVE', value: namespaceParams.getScNative()),
+      string(name: 'ENTITLEMENT_APPROACH', value: namespaceParams.getEntitlementApproach().name()),
       booleanParam(name: 'RUN_SANITY_CHECK', value: namespaceParams.getRunSanityCheck()),
       string(name: 'MEMBERS', value: namespaceParams.getMembers())]
   return jobResult


### PR DESCRIPTION
## Summary

Adds `ENTITLEMENT_APPROACH` pipeline parameter to select between two MTE entitlement methods:

- **STATE** (default) — `PUT /entitlements/state` (declarative, idempotent). Compares desired state vs current and auto-entitles/upgrades/revokes.
- **CREATE** — `POST /entitlements` (procedural). Directly installs/enables applications for tenant.

This is needed because the Sunflower-base MTE module (`mgr-tenant-entitlements`) does not expose the `/entitlements/state` endpoint, causing HTTP 404 errors during environment provisioning.

## Changes

- **`EntitlementApproach.groovy`** — New enum (`STATE`, `CREATE`)
- **`Tenants.groovy`** — Split into `enableApplications()` (POST) and `enableDesiredApplications()` (PUT /state), with shared `trackEntitlementFlow()` helper for async flow polling
- **`CreateNamespaceParameters.groovy`** — Added `entitlementApproach` field and builder method
- **`Eureka.groovy`** — Threaded `EntitlementApproach` through `initializeFromScratch()` → `createTenantFlow()` with method dispatch
- **`folioNamespaceCreateEureka.groovy`** — Passes `args.entitlementApproach` to `initializeFromScratch()`
- **`createNamespaceFromBranch/Jenkinsfile`** — Added `ENTITLEMENT_APPROACH` choice parameter (hidden for OKAPI platform)
- **`folioTriggerJob.groovy`** — Forwards `ENTITLEMENT_APPROACH` for remote job triggers