### PR TITLE
RANCHER-2883. Show experimental applications as unchecked in Jenkins pipeline UI

### DIFF
--- a/vars/folioDefault.groovy
+++ b/vars/folioDefault.groovy
@@ -7,7 +7,8 @@ Map getPlatformDescriptor(String branch = 'snapshot') {
 
   int requiredCount = platformDescriptor.applications?.required?.size() ?: 0
   int optionalCount = platformDescriptor.applications?.optional?.size() ?: 0
-  println "Fetched platform-descriptor.json with ${requiredCount} required and ${optionalCount} optional applications"
+  int experimentalCount = platformDescriptor.applications?.experimental?.size() ?: 0
+  println "Fetched platform-descriptor.json with ${requiredCount} required, ${optionalCount} optional, and ${experimentalCount} experimental applications"
 
   return platformDescriptor
 }
@@ -27,7 +28,8 @@ List<Map<String, String>> getAllPlatformApps(String branch = 'snapshot', Map pla
   }
 
   List allApps = (platformDescriptor.applications?.required ?: []) +
-                                       (platformDescriptor.applications?.optional ?: [])
+                 (platformDescriptor.applications?.optional ?: []) +
+                 (platformDescriptor.applications?.experimental ?: [])
 
   return allApps as List<Map<String, String>>
 }

--- a/vars/folioStringScripts.groovy
+++ b/vars/folioStringScripts.groovy
@@ -69,6 +69,9 @@ try {
   descriptor.applications.optional.each { app ->
     apps.add(app['name'] + ':selected')
   }
+  descriptor.applications.experimental?.each { app ->
+    apps.add(app['name'])
+  }
 
   return apps
 } catch (Exception e) {


### PR DESCRIPTION
## Summary

Displays experimental applications from `platform-descriptor.json` as **unchecked** checkboxes in the Jenkins `createNamespaceFromBranch` pipeline UI, requiring explicit user opt-in. Required and optional applications remain checked by default.

## Changes

- **`vars/folioStringScripts.groovy`** — Add `experimental?.each` loop in `getApplicationsFromPlatformDescriptor()` that appends app names **without** `:selected` suffix (unchecked in UI)
- **`vars/folioDefault.groovy`** — Include experimental apps in `getAllPlatformApps()` so selected experimental apps can be resolved to name+version for deployment; update `getPlatformDescriptor()` log to show experimental count

`getApplicationNamesFromPlatform()` intentionally unchanged — automated pipelines continue deploying only required+optional apps (matching the UI default of unchecked).

## Dependencies

- Requires [RANCHER-2876](https://folio-org.atlassian.net/browse/RANCHER-2876) (experimental section in `platform-descriptor.json`)

Refs [RANCHER-2883](https://folio-org.atlassian.net/browse/RANCHER-2883)