### PR TITLE
RANCHER-2936. Release-aware pipeline configuration for Eureka namespace creation

### DIFF
--- a/pipelines/folioRancher/folioNamespaceTools/manageNamespace/createNamespace/Jenkinsfile
+++ b/pipelines/folioRancher/folioNamespaceTools/manageNamespace/createNamespace/Jenkinsfile
@@ -1,6 +1,8 @@
 #!groovy
+package folioRancher.folioNamespaceTools.manageNamespace.createNamespace
 
 import org.folio.models.parameters.CreateNamespaceParameters
+import org.folio.Constants
 import org.jenkinsci.plugins.workflow.libs.Library
 
 @Library('pipelines-shared-library') _
@@ -10,15 +12,18 @@ properties([
   parameters([
     folioParameters.cluster(),
     folioParameters.namespace(),
-    booleanParam(name: 'RW_SPLIT', defaultValue: false, description: '(Optional) Set true to Enable Read/Write split'),
-    booleanParam(name: 'GREENMAIL', defaultValue: false, description: '(Optional) Set true to deploy greenmail server'),
-    booleanParam(name: 'MOCK_SERVER', defaultValue: false, description: '(Optional) Set true to deploy mock-server'),
-    folioParameters.pgType(),
-    folioParameters.pgVersion(),
-    folioParameters.kafkaType(),
-    folioParameters.opensearchType(),
-    folioParameters.s3Type(),
+    folioParameters.platformFromCluster(),
+    folioParameters.platformBranch(),
+    folioParameters.branch(),
+    booleanParam(name: 'CONSORTIA', defaultValue: true, description: '(Optional) Set true to create consortium'),
     folioParameters.refreshParameters()
+    , folioParameters.hideParameters(['PLATFORM'])
+    , folioParameters.hideParameters(
+    [
+      'EUREKA': ['FOLIO_BRANCH'],
+      'OKAPI' : ['PLATFORM_BRANCH']
+    ]
+    , 'PLATFORM')
   ])
 ])
 
@@ -27,26 +32,14 @@ if (params.REFRESH_PARAMETERS) {
   return
 }
 
-if (params.CLUSTER == 'folio-testing') {
-  folioCommon.kitfoxApproval()
-}
+folioCommon.validateNamespace(params.NAMESPACE)
 
 CreateNamespaceParameters namespaceParams = new CreateNamespaceParameters.Builder()
   .clusterName(params.CLUSTER)
   .namespaceName(params.NAMESPACE)
-  .rwSplit(params.RW_SPLIT)
-  .greenmail(params.GREENMAIL)
-  .mockServer(params.MOCK_SERVER)
-  .pgType(params.POSTGRESQL)
-  .pgVersion(params.DB_VERSION)
-  .kafkaType(params.KAFKA)
-  .opensearchType(params.OPENSEARCH)
-  .s3Type(params.S3_BUCKET)
-  .namespaceOnly(true)
-  .build()
+  .platformBranch(params.PLATFORM_BRANCH)
+  .folioBranch(params.FOLIO_BRANCH)
+  .consortia(params.CONSORTIA)
+  .build(this)
 
-folioCommon.validateNamespace(params.NAMESPACE)
-
-ansiColor('xterm') {
-  folioNamespaceCreate.call(namespaceParams)
-}
+folioTriggerJob.createNamespaceFromBranch(Constants.JENKINS_CREATE_NAMESPACE_FROM_BRANCH_JOB, namespaceParams)

--- a/pipelines/folioRancher/folioNamespaceTools/manageNamespace/createNamespace/Jenkinsfile
+++ b/pipelines/folioRancher/folioNamespaceTools/manageNamespace/createNamespace/Jenkinsfile
@@ -1,11 +1,16 @@
 #!groovy
 package folioRancher.folioNamespaceTools.manageNamespace.createNamespace
 
-import org.folio.models.parameters.CreateNamespaceParameters
+import groovy.transform.Field
 import org.folio.Constants
+import org.folio.jenkins.PodTemplates
+import org.folio.models.parameters.CreateNamespaceParameters
 import org.jenkinsci.plugins.workflow.libs.Library
 
 @Library('pipelines-shared-library') _
+
+@Field final String createNamespaceJobName = Constants.JENKINS_CREATE_NAMESPACE_FROM_BRANCH_JOB
+@Field final String deleteNamespaceJobName = Constants.JENKINS_DELETE_NAMESPACE_JOB
 
 properties([
   buildDiscarder(logRotator(numToKeepStr: '30')),
@@ -32,9 +37,13 @@ if (params.REFRESH_PARAMETERS) {
   return
 }
 
-folioCommon.validateNamespace(params.NAMESPACE)
+if (params.CLUSTER != 'folio-tmp') {
+  folioCommon.validateNamespace(params.NAMESPACE)
+}
 
-CreateNamespaceParameters namespaceParams = new CreateNamespaceParameters.Builder()
+PodTemplates podTemplates = new PodTemplates(this)
+
+CreateNamespaceParameters namespace = new CreateNamespaceParameters.Builder()
   .clusterName(params.CLUSTER)
   .namespaceName(params.NAMESPACE)
   .platformBranch(params.PLATFORM_BRANCH)
@@ -42,4 +51,42 @@ CreateNamespaceParameters namespaceParams = new CreateNamespaceParameters.Builde
   .consortia(params.CONSORTIA)
   .build(this)
 
-folioTriggerJob.createNamespaceFromBranch(Constants.JENKINS_CREATE_NAMESPACE_FROM_BRANCH_JOB, namespaceParams)
+ansiColor('xterm') {
+  podTemplates.rancherAgent {
+    stage('Checkout') {
+      checkout scm
+    }
+
+    stage('Build name') {
+      buildName "${namespace.getClusterName()}-${namespace.getNamespaceName()}.${env.BUILD_ID}"
+      buildDescription "Branch: ${namespace.getPlatformBranch()}\nConfig: ${namespace.getConfigType()}"
+    }
+
+    boolean nsExists = false
+    stage('Check existing namespace') {
+      folioHelm.withKubeConfig(namespace.getClusterName()) {
+        nsExists = kubectl.checkNamespaceExistence(namespace.getNamespaceName())
+      }
+    }
+
+    if (nsExists) {
+      stage('Confirm deletion') {
+        timeout(time: 30, unit: 'MINUTES') {
+          input(
+            id: 'ConfirmDelete',
+            message: "Namespace '${namespace.getNamespaceName()}' already exists on cluster '${namespace.getClusterName()}'. Delete it before re-creating?",
+            ok: 'Delete and re-create'
+          )
+        }
+      }
+
+      stage('Cleaning env') {
+        folioTriggerJob.deleteNamespace(deleteNamespaceJobName, namespace)
+      }
+    }
+
+    stage('Spinning up env') {
+      folioTriggerJob.createNamespaceFromBranch(createNamespaceJobName, namespace)
+    }
+  }
+}

--- a/pipelines/folioRancher/folioNamespaceTools/manageNamespace/createNamespace/Jenkinsfile
+++ b/pipelines/folioRancher/folioNamespaceTools/manageNamespace/createNamespace/Jenkinsfile
@@ -21,15 +21,20 @@ properties([
     folioParameters.platformBranch(),
     folioParameters.branch(),
     booleanParam(name: 'CONSORTIA', defaultValue: true, description: '(Optional) Set true to create consortium'),
+    booleanParam(name: 'FORCE_DELETE_IF_EXISTS', defaultValue: false, description: '(Internal) Skip the deletion confirmation prompt when the namespace already exists. Used by automation/cron.'),
     folioParameters.refreshParameters()
-    , folioParameters.hideParameters(['PLATFORM'])
+    , folioParameters.hideParameters(['PLATFORM', 'FORCE_DELETE_IF_EXISTS'])
     , folioParameters.hideParameters(
     [
       'EUREKA': ['FOLIO_BRANCH'],
       'OKAPI' : ['PLATFORM_BRANCH']
     ]
     , 'PLATFORM')
-  ])
+  ]),
+  pipelineTriggers([
+    parameterizedCron('''
+      H 20 * * * %CLUSTER=folio-edev;NAMESPACE=eureka;PLATFORM_BRANCH=snapshot;FORCE_DELETE_IF_EXISTS=true
+    ''')])
 ])
 
 if (params.REFRESH_PARAMETERS) {
@@ -70,13 +75,15 @@ ansiColor('xterm') {
     }
 
     if (nsExists) {
-      stage('Confirm deletion') {
-        timeout(time: 30, unit: 'MINUTES') {
-          input(
-            id: 'ConfirmDelete',
-            message: "Namespace '${namespace.getNamespaceName()}' already exists on cluster '${namespace.getClusterName()}'. Delete it before re-creating?",
-            ok: 'Delete and re-create'
-          )
+      if(!params.FORCE_DELETE_IF_EXISTS) {
+        stage('Confirm deletion') {
+          timeout(time: 30, unit: 'MINUTES') {
+            input(
+              id: 'ConfirmDelete',
+              message: "Namespace '${namespace.getNamespaceName()}' already exists on cluster '${namespace.getClusterName()}'. Delete it before re-creating?",
+              ok: 'Delete and re-create'
+            )
+          }
         }
       }
 

--- a/pipelines/folioRancher/folioNamespaceTools/manageNamespace/createNamespaceFromBranch/Jenkinsfile
+++ b/pipelines/folioRancher/folioNamespaceTools/manageNamespace/createNamespaceFromBranch/Jenkinsfile
@@ -6,8 +6,10 @@ import org.folio.models.OkapiUser
 import org.folio.models.RancherNamespace
 import org.folio.models.parameters.CreateNamespaceParameters
 import org.folio.models.parameters.CypressTestsParameters
+import org.folio.models.parameters.InitializeFromScratchParameters
 import org.folio.Constants
 import org.folio.rest_v2.EntitlementApproach
+import org.folio.rest_v2.FolioRelease
 import org.folio.rest_v2.PlatformType
 import org.jenkinsci.plugins.workflow.libs.Library
 
@@ -27,7 +29,7 @@ properties([
     booleanParam(name: 'SC_NATIVE', defaultValue: true, description: '(Optional) Set false to use Java based SC image'),
     folioParameters.groupParameters('Environment features'
       , ['LOAD_REFERENCE', 'LOAD_SAMPLE', 'BUILD_UI', 'CONSORTIA', 'CONSORTIA_SINGLE_UI', 'CONSORTIA_EXTRA', 'LINKED_DATA', 'MARC_MIGRATIONS', 'RTAC_CACHE',  'EDGE_LOCATE'
-         , 'SPLIT_FILES', 'RW_SPLIT', 'ECS_CCL', 'GREENMAIL', 'MOCK_SERVER', 'RTR', 'DATASET', 'TYPE', 'ENTITLEMENT_APPROACH'
+         , 'SPLIT_FILES', 'RW_SPLIT', 'ECS_CCL', 'GREENMAIL', 'MOCK_SERVER', 'RTR', 'DATASET', 'TYPE', 'ENTITLEMENT_APPROACH', 'SET_BASE_URL'
          , 'HAS_SECURE_TENANT', 'SECURE_TENANT', 'FOLIO_KEYCLOAK_VERSION', 'FOLIO_KONG_VERSION'
     ]),
     folioParameters.loadReference(),
@@ -51,6 +53,7 @@ properties([
     booleanParam(name: 'DATASET', defaultValue: false, description: '(Optional) Set true to build BF like environment'),
     choice(name: 'TYPE', choices: ['full', 'terraform', 'update'], description: '(Required) Set action TYPE to perform'),
     choice(name: 'ENTITLEMENT_APPROACH', choices: ['STATE', 'CREATE'], description: '(Optional) Entitlement method: STATE = PUT /entitlements/state (declarative), CREATE = POST /entitlements (procedural)'),
+    booleanParam(name: 'SET_BASE_URL', defaultValue: true, description: '(Optional) Set false to skip PUT /base-url during tenant configuration (e.g. for Sunflower)'),
     string(name: 'DB_BACKUP_NAME', defaultValue: Constants.BUGFEST_SNAPSHOT_NAME, description: '(Optional) Set name of the DB backup to restore'),
     string(name: 'FOLIO_KEYCLOAK_VERSION', defaultValue: 'latest', description: '(Optional) Set FOLIO Keycloak tag, example: 21.0.1-SNAPSHOT.f959523'),
     string(name: 'FOLIO_KONG_VERSION', defaultValue: 'latest', description: '(Optional) Set FOLIO Kong tag, example: 3.10.0-SNAPSHOT.f959523'),
@@ -66,7 +69,7 @@ properties([
     , folioParameters.hideParameters(
     [
       'EUREKA': ['OKAPI_VERSION', 'EDGE_LOCATE', 'RTAC_CACHE', 'FOLIO_BRANCH', 'LINKED_DATA', 'MARC_MIGRATIONS', 'FOLIO_KEYCLOAK_VERSION', 'FOLIO_KONG_VERSION'],
-      'OKAPI' : ['PLATFORM_BRANCH', 'APPLICATIONS', 'SC_NATIVE', 'ENTITLEMENT_APPROACH']
+      'OKAPI' : ['PLATFORM_BRANCH', 'APPLICATIONS', 'SC_NATIVE', 'ENTITLEMENT_APPROACH', 'SET_BASE_URL']
     ]
     , 'PLATFORM')
     , folioParameters.hideParameters(
@@ -129,8 +132,11 @@ CreateNamespaceParameters namespaceParams = new CreateNamespaceParameters.Builde
   .dataset(params.DATASET)
   .type(params.TYPE)
   .scNative(params.SC_NATIVE)
-  .entitlementApproach(EntitlementApproach.valueOf(params.ENTITLEMENT_APPROACH))
-  .build()
+  .initParams(new InitializeFromScratchParameters()
+    .withEntitlementApproach(EntitlementApproach.valueOf(params.ENTITLEMENT_APPROACH))
+    .withSetBaseUrl(params.SET_BASE_URL))
+  .releaseType(FolioRelease.fromPlatformVersion(params.PLATFORM_BRANCH))
+  .build(this)
 
 if (params.CONSORTIA) {
     if (namespaceParams.platform == PlatformType.EUREKA) {

--- a/pipelines/folioRancher/folioNamespaceTools/manageNamespace/createNamespaceFromBranch/Jenkinsfile
+++ b/pipelines/folioRancher/folioNamespaceTools/manageNamespace/createNamespaceFromBranch/Jenkinsfile
@@ -9,7 +9,6 @@ import org.folio.models.parameters.CypressTestsParameters
 import org.folio.models.parameters.InitializeFromScratchParameters
 import org.folio.Constants
 import org.folio.rest_v2.EntitlementApproach
-import org.folio.rest_v2.FolioRelease
 import org.folio.rest_v2.PlatformType
 import org.jenkinsci.plugins.workflow.libs.Library
 
@@ -135,14 +134,12 @@ CreateNamespaceParameters namespaceParams = new CreateNamespaceParameters.Builde
   .initParams(new InitializeFromScratchParameters()
     .withEntitlementApproach(EntitlementApproach.valueOf(params.ENTITLEMENT_APPROACH))
     .withSetBaseUrl(params.SET_BASE_URL))
-  .releaseType(FolioRelease.fromPlatformVersion(params.PLATFORM_BRANCH))
   .build(this)
 
 if (params.CONSORTIA) {
     if (namespaceParams.platform == PlatformType.EUREKA) {
         namespaceParams.folioExtensions.add('consortia-eureka')
-    }
-    else {
+    } else {
         namespaceParams.folioExtensions.add('consortia')
     }
 }
@@ -189,7 +186,7 @@ if (namespaceParams.platform == PlatformType.EUREKA) {
 ansiColor('xterm') {
     if (namespaceParams.platform == PlatformType.EUREKA) {
         folioNamespaceCreateEureka.call(namespaceParams)
-  } else {
+    } else {
         folioNamespaceCreate.call(namespaceParams)
     }
 

--- a/pipelines/folioRancher/folioNamespaceTools/manageNamespace/recreateTeamNamespace/Jenkinsfile
+++ b/pipelines/folioRancher/folioNamespaceTools/manageNamespace/recreateTeamNamespace/Jenkinsfile
@@ -1,12 +1,12 @@
 #!groovy
+package folioRancher.folioNamespaceTools.manageNamespace.recreateTeamNamespace
+
 import groovy.transform.Field
 import org.folio.Constants
 import org.folio.jenkins.PodTemplates
 import org.folio.models.parameters.CreateNamespaceParameters
-import org.folio.rest_v2.PlatformType
 import org.jenkinsci.plugins.workflow.libs.Library
 
-//TODO remove branch before merge to master
 @Library('pipelines-shared-library') _
 
 @Field final String deleteNamespaceJobName = Constants.JENKINS_DELETE_NAMESPACE_JOB
@@ -14,25 +14,27 @@ import org.jenkinsci.plugins.workflow.libs.Library
 
 properties([
   buildDiscarder(logRotator(numToKeepStr: '30')),
-  parameters([folioParameters.platform(),
-              folioParameters.cluster('PLATFORM'),
-              folioParameters.namespace(),
-              folioParameters.platformBranch(),
-              folioParameters.configType(),
-              booleanParam(name: 'SC_NATIVE', defaultValue: true, description: '(Optional) Set false to use Java based SC image'),
-              booleanParam(name: 'CONSORTIA_EXTRA', defaultValue: false, description: '(Optional) Set true to include 2nd consortium'),
-              booleanParam(name: 'SANITY_CHECK', defaultValue: false, description: '(Optional) Set true to run sanity check after environment is up'),
-              folioParameters.refreshParameters()]),
+  parameters([
+    folioParameters.cluster(),
+    folioParameters.namespace(),
+    folioParameters.platformFromCluster(),
+    folioParameters.platformBranch(),
+    folioParameters.branch(),
+    booleanParam(name: 'CONSORTIA', defaultValue: true, description: '(Optional) Set true to create consortium'),
+    folioParameters.refreshParameters()
+    , folioParameters.hideParameters(['PLATFORM'])
+    , folioParameters.hideParameters(
+    [
+      'EUREKA': ['FOLIO_BRANCH'],
+      'OKAPI' : ['PLATFORM_BRANCH']
+    ]
+    , 'PLATFORM')
+  ]),
   pipelineTriggers([
     parameterizedCron('''
-      H 20 * * * %PLATFORM=EUREKA;CLUSTER=folio-edev;NAMESPACE=eureka;CONFIG_TYPE=development
+      H 20 * * * %PLATFORM=EUREKA;CLUSTER=folio-edev;NAMESPACE=eureka;PLATFORM_BRANCH=snapshot
     ''')])
 ])
-// Get back when the ticket is resolved https://folio-org.atlassian.net/browse/RANCHER-1546
-//            pipelineTriggers([parameterizedCron('''
-//              H 20 * * * %CLUSTER=folio-edev;NAMESPACE=eureka;EUREKA=true;CONFIG_TYPE=development;AGENT=rancher
-//            ''')])])
-
 
 if (params.REFRESH_PARAMETERS) {
   currentBuild.result = 'ABORTED'
@@ -46,35 +48,12 @@ if (params.CONFIG_TYPE == 'release') {
 PodTemplates podTemplates = new PodTemplates(this)
 
 CreateNamespaceParameters namespace = new CreateNamespaceParameters.Builder()
-  .platform(PlatformType.EUREKA)
   .clusterName(params.CLUSTER)
   .namespaceName(params.NAMESPACE)
-  .folioBranch('snapshot')
   .platformBranch(params.PLATFORM_BRANCH)
-  .okapiVersion('latest')
-  .configType(params.CONFIG_TYPE)
-  .loadReference(true)
-  .loadSample(true)
-  .consortia(true)
-  .consortiaExtra(params.CONSORTIA_EXTRA)
-  .rwSplit(false)
-  .greenmail(false)
-  .mockServer(false)
-  .rtr(false)
+  .folioBranch(params.FOLIO_BRANCH)
   .splitFiles(true)
-  .ecsCCL(false)
-  .hasSecureTenant(true)
-  .secureTenantId(folioDefault.consortiaTenants().get('university').getTenantId())
-  .dataset(false)
-  .pgType('built-in')
-  .pgVersion('16.8')
-  .kafkaType('built-in')
-  .opensearchType('aws')
-  .scNative(params.SC_NATIVE)
-  .s3Type('built-in')
-  .uiBuild(true)
-  .runSanityCheck(params.SANITY_CHECK)
-  .build()
+  .build(this)
 
 ansiColor('xterm') {
   podTemplates.rancherAgent {
@@ -82,13 +61,9 @@ ansiColor('xterm') {
       checkout scm
     }
 
-    stage('Fetch Applications') {
-      namespace.applications = folioDefault.getApplicationNamesFromPlatform(params.PLATFORM_BRANCH)
-    }
-
     stage('Build name') {
       buildName "${namespace.getClusterName()}-${namespace.getNamespaceName()}.${env.BUILD_ID}"
-      buildDescription "Config: ${params.CONFIG_TYPE}"
+      buildDescription "Branch: ${namespace.getPlatformBranch()}\nConfig: ${namespace.getConfigType()}"
     }
 
     stage('Cleaning env') {

--- a/pipelines/folioRancher/folioNamespaceTools/manageNamespace/recreateTeamNamespace/Jenkinsfile
+++ b/pipelines/folioRancher/folioNamespaceTools/manageNamespace/recreateTeamNamespace/Jenkinsfile
@@ -41,6 +41,12 @@ if (params.REFRESH_PARAMETERS) {
   return
 }
 
+// DEPRECATED: This pipeline is replaced by folioRancher/manageNamespace/createNamespace.
+// createNamespace performs the same delete-then-create flow with a UI confirmation prompt
+// for interactive runs and FORCE_DELETE_IF_EXISTS=true for unattended/cron runs.
+error("This pipeline is deprecated. Use 'folioRancher/manageNamespace/createNamespace' instead " +
+  "(set FORCE_DELETE_IF_EXISTS=true for unattended runs).")
+
 if (params.CONFIG_TYPE == 'release') {
   folioCommon.kitfoxApproval()
 }

--- a/pipelines/folioRancher/folioScheduledProvisioning/createDailySnapshotEureka/Jenkinsfile
+++ b/pipelines/folioRancher/folioScheduledProvisioning/createDailySnapshotEureka/Jenkinsfile
@@ -1,12 +1,12 @@
 #!groovy
+package folioRancher.folioScheduledProvisioning.createDailySnapshotEureka
+
 import groovy.transform.Field
 import org.folio.Constants
 import org.folio.jenkins.PodTemplates
 import org.folio.models.parameters.CreateNamespaceParameters
-import org.folio.rest_v2.PlatformType
 import org.jenkinsci.plugins.workflow.libs.Library
 
-//TODO remove branch before merge to master
 @Library('pipelines-shared-library') _
 
 @Field final String deleteNamespaceJobName = Constants.JENKINS_DELETE_NAMESPACE_JOB
@@ -28,77 +28,25 @@ if (params.REFRESH_PARAMETERS) {
 PodTemplates podTemplates = new PodTemplates(this)
 
 CreateNamespaceParameters namespace1 = new CreateNamespaceParameters.Builder()
-  .platform(PlatformType.EUREKA)
   .clusterName('folio-etesting')
   .namespaceName('snapshot')
-  .folioBranch('snapshot')
   .platformBranch('snapshot')
-  .okapiVersion('latest')
-  .configType('testing')
-  .loadReference(true)
-  .loadSample(true)
-  .consortia(true)
-  .rwSplit(false)
   .splitFiles(true)
-  .greenmail(false)
-  .mockServer(false)
-  .rtr(false)
   .ecsCCL(true)
-  .hasSecureTenant(true)
-  .secureTenantId(folioDefault.consortiaTenants().get('university').getTenantId())
-  .dataset(false)
-  .pgType('built-in')
-  .pgVersion('16.8')
-  .kafkaType('built-in')
-  .opensearchType('aws')
-  .s3Type('built-in')
-  .scNative(true)
-  .members('thunderjet,folijet,spitfire,vega,thor,Eureka,volaris,corsair,Bama,Aggies,Dreamliner,Leipzig,firebird,dojo,erm')
-  .uiBuild(true)
-  .runSanityCheck(false)
-  .build()
+  .build(this)
 
 CreateNamespaceParameters namespace2 = new CreateNamespaceParameters.Builder()
-  .platform(PlatformType.EUREKA)
   .clusterName('folio-etesting')
   .namespaceName('snapshot2')
-  .folioBranch('snapshot')
   .platformBranch('snapshot')
-  .okapiVersion('latest')
-  .configType('testing')
-  .loadReference(true)
-  .loadSample(true)
-  .consortia(true)
-  .rwSplit(false)
   .splitFiles(true)
-  .greenmail(false)
-  .mockServer(false)
-  .rtr(false)
   .ecsCCL(true)
-  .hasSecureTenant(true)
-  .secureTenantId(folioDefault.consortiaTenants().get('university').getTenantId())
-  .dataset(false)
-  .pgType('built-in')
-  .pgVersion('16.8')
-  .kafkaType('built-in')
-  .opensearchType('aws')
-  .s3Type('built-in')
-  .scNative(true)
-  .members('thunderjet,folijet,spitfire,vega,thor,Eureka,volaris,corsair,Bama,Aggies,Dreamliner,Leipzig,firebird,dojo,erm')
-  .uiBuild(true)
-  .runSanityCheck(false)
-  .build()
+  .build(this)
 
 ansiColor('xterm') {
   podTemplates.rancherAgent {
     stage('Checkout') {
       checkout scm
-    }
-
-    stage('Fetch Applications') {
-      List<String> appNames = folioDefault.getApplicationNamesFromPlatform('snapshot')
-      namespace1.applications = appNames
-      namespace2.applications = appNames
     }
 
     CreateNamespaceParameters createdEnv = namespace1

--- a/pipelines/folioRancher/folioScheduledProvisioning/updateSprintTestingEureka/Jenkinsfile
+++ b/pipelines/folioRancher/folioScheduledProvisioning/updateSprintTestingEureka/Jenkinsfile
@@ -70,48 +70,25 @@ if (params.IS_CRON_JOB) {
 }
 
 CreateNamespaceParameters namespace = new CreateNamespaceParameters.Builder()
-  .platform(PlatformType.EUREKA)
   .clusterName(params.CLUSTER)
   .namespaceName(params.NAMESPACE)
-  .folioBranch('snapshot')
   .platformBranch('snapshot')
-  .okapiVersion('latest')
   .configType(params.CONFIG_TYPE)
   .loadReference(false)
   .loadSample(false)
-  .consortia(true)
-  .rwSplit(false)
-  .greenmail(false)
-  .mockServer(false)
-  .rtr(false)
   .splitFiles(true)
-  .ecsCCL(false)
   .dbBackupName(params.DB_BACKUP_NAME)
   .doMarcMigrations(params.MARC_MIGRATIONS)
   .type(params.TYPE)
   .hasSecureTenant(false)
-  .secureTenantId(folioDefault.consortiaTenants().get('university').getTenantId())
-  .dataset(true)
-  .pgType('aws')
-  .pgVersion('16.8')
-  .kafkaType('aws')
-  .opensearchType('aws')
-  .s3Type('aws')
-  .scNative(true)
   .uiBuild(false)
-  .runSanityCheck(false)
-  .members('thunderjet,folijet,spitfire,vega,thor,Eureka,volaris,corsair,Bama,Aggies,Dreamliner,Leipzig,firebird,dojo,erm')
-  .build()
+  .build(this)
 
 ansiColor('xterm') {
-  stage('Fetch Applications') {
-    List<String> appNames = folioDefault.getApplicationNamesFromPlatform('snapshot')
-
+  stage('Filter Applications') {
     if (!params.MARC_MIGRATIONS) {
-      appNames = appNames.findAll { it != 'app-marc-migrations' }
+      namespace.applications = namespace.applications.findAll { it != 'app-marc-migrations' }
     }
-
-    namespace.applications = appNames
   }
 
   stage('Update Sprint Testing') {

--- a/pipelines/folioRancher/folioScheduledTesting/folioQualityGates/Jenkinsfile
+++ b/pipelines/folioRancher/folioScheduledTesting/folioQualityGates/Jenkinsfile
@@ -57,34 +57,17 @@ if (params.INCLUDE_KARATE) {
 }
 
 CreateNamespaceParameters namespaceBaseParams = new CreateNamespaceParameters.Builder()
-  .rwSplit(false)
-  .greenmail(false)
   .mockServer(true)
-  .pgType('built-in')
-  .pgVersion('16.8')
-  .kafkaType('built-in')
   .opensearchType('built-in')
-  .s3Type('built-in')
-  .runSanityCheck(false)
-  .members('')
   .build()
 
 CreateNamespaceParameters namespaceFromBranchParams = namespaceBaseParams.toBuilder()
-  .folioBranch(params.FOLIO_BRANCH)
   .platformBranch(params.FOLIO_BRANCH)
-  .okapiVersion(okapiVersion)
   .configType('testing')
-  .loadReference(true)
-  .loadSample(true)
   .mockServer(false)
-  .consortia(true)
   .splitFiles(true)
-  .ecsCCL(false)
-  .rtr(false)
   .scNative(true)
-  .hasSecureTenant(true)
-  .secureTenantId(folioDefault.consortiaTenants().get('university').getTenantId())
-  .build()
+  .build(this)
 
 ansiColor('xterm') {
   try {
@@ -111,9 +94,6 @@ ansiColor('xterm') {
         }
       }
 
-      stage('Fetch Applications') {
-        namespaceFromBranchParams.applications = folioDefault.getApplicationNamesFromPlatform(params.FOLIO_BRANCH)
-      }
     }
 
     if (autoCanceled) {

--- a/pipelines/folioRancher/folioScheduledTesting/runNightlyCypressEurekaTests/Jenkinsfile
+++ b/pipelines/folioRancher/folioScheduledTesting/runNightlyCypressEurekaTests/Jenkinsfile
@@ -44,34 +44,15 @@ Logger logger = new Logger(this, env.JOB_BASE_NAME)
 final String platformCompleteBranch = 'snapshot'
 
 CreateNamespaceParameters namespaceBaseParams = new CreateNamespaceParameters.Builder()
-  .platform(PlatformType.EUREKA)
   .clusterName('folio-etesting')
   .namespaceName('cypress')
-  .rwSplit(false)
-  .greenmail(false)
-  .mockServer(false)
-  .pgType('built-in')
-  .pgVersion('16.8')
   .kafkaType('aws')
-  .opensearchType('aws')
-  .s3Type('built-in')
-  .members('AQA')
-  .build()
+  .build(this)
 
 CreateNamespaceParameters namespaceFromBranchParams = namespaceBaseParams.toBuilder()
   .folioBranch(platformCompleteBranch)
   .platformBranch(platformCompleteBranch)
-  .okapiVersion('latest')
-  .configType('testing')
-  .loadReference(true)
-  .loadSample(true)
-  .consortia(true)
-  .rtr(false)
-  .scNative(true)
-  .hasSecureTenant(true)
-  .secureTenantId(folioDefault.consortiaTenants().get('university').getTenantId())
-  .uiBuild(true)
-  .build()
+  .build(this)
 
 RancherNamespace namespace = new RancherNamespace(namespaceBaseParams.getClusterName(), namespaceBaseParams.getNamespaceName())
 
@@ -98,10 +79,6 @@ ansiColor('xterm') {
   podTemplates.rancherAgent {
     stage('Ini') {
       buildDescription "Branch: ${params.CYPRESS_BRANCH}\nConfig: ${namespaceFromBranchParams.getConfigType()}\nEnv: ${cypressParameters.tenantUrl}"
-    }
-
-    stage('Fetch Applications') {
-      namespaceFromBranchParams.applications = folioDefault.getApplicationNamesFromPlatform(platformCompleteBranch)
     }
 
     stage('[Job] Destroy environment') {

--- a/pipelines/folioRancher/folioScheduledTesting/runNightlyKarateEurekaTests/Jenkinsfile
+++ b/pipelines/folioRancher/folioScheduledTesting/runNightlyKarateEurekaTests/Jenkinsfile
@@ -48,38 +48,17 @@ ansiColor('xterm') {
     String okapiVersion = folioTools.eval(folioStringScripts.getOkapiVersions(), ['FOLIO_BRANCH': 'snapshot'])[0]
 
     CreateNamespaceParameters namespaceBaseParams = new CreateNamespaceParameters.Builder()
-      .platform(PlatformType.EUREKA)
       .clusterName('folio-etesting')
       .namespaceName('cikarate')
-      .rwSplit(false)
-      .greenmail(false)
-      .mockServer(false)
-      .pgType('built-in')
-      .pgVersion('16.8')
-      .kafkaType('built-in')
-      .opensearchType('aws')
-      .s3Type('built-in')
-      .runSanityCheck(false)
       .members('dojo')
-      .uiBuild(true)
-      .build()
+      .build(this)
 
     CreateNamespaceParameters namespaceFromBranchParams = namespaceBaseParams.toBuilder()
       .folioBranch('snapshot')
-      .platformBranch('snapshot')
-      .okapiVersion(okapiVersion)
-      .configType('testing')
-      .loadReference(true)
-      .loadSample(true)
       .mockServer(true)
-      .consortia(true)
       .splitFiles(true)
       .scNative(true)
-      .rtr(false)
-      .hasSecureTenant(true)
-      .secureTenantId(folioDefault.consortiaTenants().get('university').getTenantId())
-      .uiBuild(true)
-      .build()
+      .build(this)
 
     RancherNamespace namespace = new RancherNamespace(namespaceBaseParams.getClusterName(), namespaceBaseParams.getNamespaceName())
     namespace.withDefaultTenant('diku')
@@ -119,10 +98,6 @@ ansiColor('xterm') {
         } else {
           logger.warning("${namespaceBaseParams.getNamespaceName()} namespace does not exists!")
         }
-      }
-
-      stage('Fetch Applications') {
-        namespaceFromBranchParams.applications = folioDefault.getApplicationNamesFromPlatform('snapshot')
       }
 
       stage('[Job] Provision environment') {

--- a/pipelines/folioRancher/folioScheduledTesting/runNightlyKarateLSDITests/Jenkinsfile
+++ b/pipelines/folioRancher/folioScheduledTesting/runNightlyKarateLSDITests/Jenkinsfile
@@ -41,34 +41,15 @@ PodTemplates podTemplates = new PodTemplates(this)
 String okapiVersion = folioTools.eval(folioStringScripts.getOkapiVersions(), ['FOLIO_BRANCH': 'snapshot'])[0]
 
 CreateNamespaceParameters namespaceParams = new CreateNamespaceParameters.Builder()
-  .platform(PlatformType.EUREKA)
   .clusterName('folio-etesting')
   .namespaceName('lsdi')
-  .folioBranch('snapshot')
   .platformBranch('snapshot')
-  .okapiVersion(okapiVersion)
-  .configType('testing')
-  .loadReference(true)
-  .loadSample(true)
-  .consortia(true)
   .splitFiles(true)
   .ecsCCL(true)
-  .rwSplit(false)
-  .greenmail(false)
-  .mockServer(false)
-  .rtr(false)
-  .hasSecureTenant(true)
-  .secureTenantId(folioDefault.consortiaTenants().get('university').getTenantId())
-  .pgType('built-in')
-  .pgVersion('16.8')
-  .kafkaType('built-in')
   .opensearchType('built-in')
-  .s3Type('built-in')
   .scNative(true)
   .members('folijet')
-  .uiBuild(true)
-  .worker('rancher')
-  .build()
+  .build(this)
 
 namespaceParams.folioExtensions.add('consortia-eureka')
 
@@ -104,10 +85,6 @@ ansiColor('xterm') {
 
     stage('[Job] Destroy environment (before)') {
       params.RETRY_FAILED ? println('RETRY tests execution | Skip destroy stage') : folioTriggerJob.deleteNamespace(deleteNamespaceJobName, namespaceParams)
-    }
-
-    stage('Fetch Applications') {
-      namespaceParams.applications = folioDefault.getApplicationNamesFromPlatform('snapshot')
     }
 
     stage('[Job] Provision environment') {

--- a/resources/helm/features/sunflower.yaml
+++ b/resources/helm/features/sunflower.yaml
@@ -1,0 +1,5 @@
+---
+mgr-tenant-entitlements:
+  extraEnvVars:
+    - name: VALIDATION_INTERFACE_COLLECTOR_MODE
+      value: "combined"

--- a/src/org/folio/Constants.groovy
+++ b/src/org/folio/Constants.groovy
@@ -109,7 +109,7 @@ class Constants {
     ],
     [
       name: 'folio-tmp'
-      , platform: [ PlatformType.OKAPI, PlatformType.EUREKA ]
+      , platform: [ PlatformType.EUREKA, PlatformType.OKAPI ]
       , namespaces: AWS_EKS_TMP_NAMESPACES
       , disabled: false
     ]

--- a/src/org/folio/Constants.groovy
+++ b/src/org/folio/Constants.groovy
@@ -361,7 +361,8 @@ class Constants {
                                 "vasyl_avramenko@epam.com",
                                 "eldiiar_duishenaliev@epam.com"]
 
-  static List PGSQL_VERSION = ["12.12", "13.13", "14.10", "15.5", "16.1"]
+  static String PGSQL_DEFAULT_VERSION = "16.8"
+  static List PGSQL_VERSION = [PGSQL_DEFAULT_VERSION, "16.9", "16.10", "17.6", "18.0"]
 
   static Pattern NAME_VERSION_REGEXP = ~/^([a-z_\-]+)-([\d.]+(?:-SNAPSHOT(?:\.\w+)?|))$/
 

--- a/src/org/folio/models/EurekaNamespace.groovy
+++ b/src/org/folio/models/EurekaNamespace.groovy
@@ -16,6 +16,8 @@ class EurekaNamespace extends RancherNamespace {
 
   boolean enableECS_CCL = false
 
+  List<String> configExtensions = []
+
   boolean hasSecureTenant = false
 
   EurekaTenant secureTenant
@@ -68,6 +70,12 @@ class EurekaNamespace extends RancherNamespace {
 
     if (getDeploymentConfigType() && enableECS_CCL)
       setDeploymentConfig(mergeMaps(getDeploymentConfig(), getFeatureConfig('ecs-ccl', branch)))
+
+    if (getDeploymentConfigType() && configExtensions) {
+      configExtensions.each { feature ->
+        setDeploymentConfig(mergeMaps(getDeploymentConfig(), getFeatureConfig(feature, branch)))
+      }
+    }
   }
 
   private List<EurekaTenantConsortia> findCentralConsortiaTenants() {

--- a/src/org/folio/models/RancherNamespace.groovy
+++ b/src/org/folio/models/RancherNamespace.groovy
@@ -189,7 +189,7 @@ class RancherNamespace {
     }
   }
 
-  protected Map getFeatureConfig(String feature, String branch = DEPLOYMENT_CONFIG_BRANCH) {
+  Map getFeatureConfig(String feature, String branch = DEPLOYMENT_CONFIG_BRANCH) {
     return fetchYaml("${GITHUB_SHARED_LIBRARY_RAW}/${branch}/resources/helm/features/${feature}.yaml")
   }
 
@@ -215,10 +215,7 @@ class RancherNamespace {
           // Merge maps recursively
           map1[key] = mergeMaps(map1[key] as Map, value as Map)
         } else if (map1[key] instanceof List && value instanceof List) {
-          // Merge lists
-          List mergedList = new ArrayList(map1[key])
-          mergedList.addAll(value)
-          map1[key] = mergedList.unique() // Remove duplicates, if required
+          map1[key] = mergeNamedLists(map1[key] as List, value as List)
         } else {
           map1[key] = value
         }
@@ -227,6 +224,25 @@ class RancherNamespace {
       }
     }
     return map1
+  }
+
+  /**
+   * Merges two lists. When all elements in both lists are Maps containing a 'name' key
+   * (the standard Kubernetes env var pattern), entries are deduplicated by 'name' with
+   * the second list overriding the first. Otherwise, falls back to append + unique.
+   */
+  protected static List mergeNamedLists(List list1, List list2) {
+    boolean isNamedMapList = !(list1 + list2).isEmpty() &&
+      (list1 + list2).every { it instanceof Map && (it as Map).containsKey('name') }
+    if (isNamedMapList) {
+      Map<String, Map> byName = new LinkedHashMap<>()
+      list1.each { byName[(it as Map).name as String] = it as Map }
+      list2.each { byName[(it as Map).name as String] = it as Map }
+      return byName.values().toList()
+    }
+    List merged = new ArrayList(list1)
+    merged.addAll(list2)
+    return merged.unique()
   }
 
   String getWorkspaceName() {

--- a/src/org/folio/models/parameters/CreateNamespaceParameters.groovy
+++ b/src/org/folio/models/parameters/CreateNamespaceParameters.groovy
@@ -54,7 +54,7 @@ class CreateNamespaceParameters implements Cloneable {
 
   boolean hasSecureTenant = true
 
-  String secureTenantId = folioDefault.consortiaTenants().get('university').getTenantId()
+  String secureTenantId = 'university'
 
   boolean uiBuild = true
 
@@ -436,7 +436,7 @@ class CreateNamespaceParameters implements Cloneable {
 
     CreateNamespaceParameters build(def context = null) {
       Map<String, Object> defaults = DependentParametersResolver.resolve(
-        parameters.clusterName, parameters.namespaceName, parameters.releaseType)
+        parameters.clusterName, parameters.namespaceName, parameters.platformBranch, context)
 
       defaults.each { name, value ->
         if (!modifiedFields.contains(name) && value != null && parameters.hasProperty(name)) {
@@ -446,9 +446,6 @@ class CreateNamespaceParameters implements Cloneable {
 
       if (parameters.initParams.entitlementApproach == null && defaults.entitlementApproach != null)
         parameters.initParams.entitlementApproach = defaults.entitlementApproach as EntitlementApproach
-
-      if (!modifiedFields.contains('applications') && !parameters.applications && parameters.platformBranch && context)
-        parameters.applications = context.folioDefault.getApplicationNamesFromPlatform(parameters.platformBranch)
 
       return parameters
     }

--- a/src/org/folio/models/parameters/CreateNamespaceParameters.groovy
+++ b/src/org/folio/models/parameters/CreateNamespaceParameters.groovy
@@ -1,7 +1,9 @@
 package org.folio.models.parameters
 
 import com.cloudbees.groovy.cps.NonCPS
+import org.folio.Constants
 import org.folio.rest_v2.EntitlementApproach
+import org.folio.rest_v2.FolioRelease
 import org.folio.rest_v2.PlatformType
 
 /**
@@ -9,6 +11,8 @@ import org.folio.rest_v2.PlatformType
  * various services and features within the FOLIO ecosystem.
  */
 class CreateNamespaceParameters implements Cloneable {
+
+  FolioRelease releaseType = FolioRelease.SNAPSHOT
 
   PlatformType platform = PlatformType.OKAPI
 
@@ -24,11 +28,11 @@ class CreateNamespaceParameters implements Cloneable {
 
   String configType
 
-  boolean loadReference
+  boolean loadReference = true
 
-  boolean loadSample
+  boolean loadSample = true
 
-  boolean consortia
+  boolean consortia = true
 
   boolean consortiaExtra = false
 
@@ -48,17 +52,17 @@ class CreateNamespaceParameters implements Cloneable {
 
   boolean marcMigrations = false
 
-  boolean hasSecureTenant
+  boolean hasSecureTenant = true
 
-  String secureTenantId
+  String secureTenantId = folioDefault.consortiaTenants().get('university').getTenantId()
 
-  boolean uiBuild
+  boolean uiBuild = true
 
   boolean dataset = false
 
-  boolean scNative = false
+  boolean scNative = true
 
-  EntitlementApproach entitlementApproach = EntitlementApproach.STATE
+  InitializeFromScratchParameters initParams = new InitializeFromScratchParameters()
 
   String dmSnapshot
 
@@ -68,15 +72,17 @@ class CreateNamespaceParameters implements Cloneable {
 
   List<String> folioExtensions = []
 
-  String pgType
+  List<String> configExtensions = []
 
-  String pgVersion
+  String pgType = 'built-in'
 
-  String kafkaType
+  String pgVersion = Constants.PGSQL_DEFAULT_VERSION
 
-  String opensearchType
+  String kafkaType = 'built-in'
 
-  String s3Type
+  String opensearchType = 'aws'
+
+  String s3Type = 'built-in'
 
   boolean runSanityCheck
 
@@ -118,29 +124,21 @@ class CreateNamespaceParameters implements Cloneable {
   static class Builder {
 
     private CreateNamespaceParameters parameters = new CreateNamespaceParameters()
+    private Set<String> modifiedFields = [] as Set
 
-    /**
-     * Constructor for Builder, initializes with default parameters.
-     */
     Builder() {}
 
-    /**
-     * Initializes the builder with an existing set of parameters for cloning or modification.
-     * @param existingParameters The existing parameters to initialize the builder with.
-     */
     Builder(CreateNamespaceParameters existingParameters) {
       this.parameters = existingParameters.clone()
     }
 
-    /**
-     * Define platform type within the namespace.
-     * @param platformType. The type of platform to use, e.g., OKAPI or EUREKA.
-     * @return Builder instance for method chaining.
-     */
-    Builder platform(PlatformType platformType) {
-      parameters.platform = platformType
+    private Builder setParam(String fieldName, Object value) {
+      parameters[fieldName] = value
+      modifiedFields << fieldName
       return this
     }
+
+    Builder platform(PlatformType platformType) { return setParam('platform', platformType) }
 
     /**
      * Sets the cluster name where the namespace will be created.
@@ -148,10 +146,7 @@ class CreateNamespaceParameters implements Cloneable {
      * @param clusterName The name of the Kubernetes cluster.
      * @return Builder instance for method chaining.
      */
-    Builder clusterName(String clusterName) {
-      parameters.clusterName = clusterName
-      return this
-    }
+    Builder clusterName(String clusterName) { return setParam('clusterName', clusterName) }
 
     /**
      * Sets the name of the namespace to be created or managed.
@@ -159,10 +154,7 @@ class CreateNamespaceParameters implements Cloneable {
      * @param namespaceName The unique name for the namespace.
      * @return Builder instance for method chaining.
      */
-    Builder namespaceName(String namespaceName) {
-      parameters.namespaceName = namespaceName
-      return this
-    }
+    Builder namespaceName(String namespaceName) { return setParam('namespaceName', namespaceName) }
 
     /**
      * Specifies the FOLIO branch for which the namespace is being configured.
@@ -170,10 +162,7 @@ class CreateNamespaceParameters implements Cloneable {
      * @param folioBranch The branch name of the FOLIO repository.
      * @return Builder instance for method chaining.
      */
-    Builder folioBranch(String folioBranch) {
-      parameters.folioBranch = folioBranch
-      return this
-    }
+    Builder folioBranch(String folioBranch) { return setParam('folioBranch', folioBranch) }
 
     /**
      * Specifies the platform-lsp branch for Eureka platform configuration.
@@ -181,10 +170,7 @@ class CreateNamespaceParameters implements Cloneable {
      * @param platformBranch The branch name of the platform-lsp repository.
      * @return Builder instance for method chaining.
      */
-    Builder platformBranch(String platformBranch) {
-      parameters.platformBranch = platformBranch
-      return this
-    }
+    Builder platformBranch(String platformBranch) { return setParam('platformBranch', platformBranch) }
 
     /**
      * Sets the version of Okapi to be deployed within the namespace.
@@ -192,20 +178,14 @@ class CreateNamespaceParameters implements Cloneable {
      * @param okapiVersion The version number of Okapi.
      * @return Builder instance for method chaining.
      */
-    Builder okapiVersion(String okapiVersion) {
-      parameters.okapiVersion = okapiVersion
-      return this
-    }
+    Builder okapiVersion(String okapiVersion) { return setParam('okapiVersion', okapiVersion) }
 
     /**
      * Defines the configuration type for the namespace, affecting how resources are allocated and managed.
      * @param configType A string indicating the configuration profile to apply.
      * @return Builder instance for method chaining.
      */
-    Builder configType(String configType) {
-      parameters.configType = configType
-      return this
-    }
+    Builder configType(String configType) { return setParam('configType', configType) }
 
     /**
      * Determines whether reference data should be loaded into the namespace.
@@ -213,10 +193,7 @@ class CreateNamespaceParameters implements Cloneable {
      * @param loadReference `true` to load reference data; `false` otherwise.
      * @return Builder instance for method chaining.
      */
-    Builder loadReference(boolean loadReference) {
-      parameters.loadReference = loadReference
-      return this
-    }
+    Builder loadReference(boolean loadReference) { return setParam('loadReference', loadReference) }
 
     /**
      * Determines whether sample data should be loaded into the namespace.
@@ -224,10 +201,7 @@ class CreateNamespaceParameters implements Cloneable {
      * @param loadSample `true` to load sample data; `false` otherwise.
      * @return Builder instance for method chaining.
      */
-    Builder loadSample(boolean loadSample) {
-      parameters.loadSample = loadSample
-      return this
-    }
+    Builder loadSample(boolean loadSample) { return setParam('loadSample', loadSample) }
 
     /**
      * Enables or disables consortia features within the namespace.
@@ -235,20 +209,14 @@ class CreateNamespaceParameters implements Cloneable {
      * @param consortia `true` to enable consortia features; `false` to disable.
      * @return Builder instance for method chaining.
      */
-    Builder consortia(boolean consortia) {
-      parameters.consortia = consortia
-      return this
-    }
+    Builder consortia(boolean consortia) { return setParam('consortia', consortia) }
 
     /**
      * Enables or disables the second consortium features within the namespace.
      * @param consortiaExtra `true` to enable the second consortium features; `false` to disable.
      * @return Builder instance for method chaining.
      */
-    Builder consortiaExtra(boolean consortiaExtra) {
-      parameters.consortiaExtra = consortiaExtra
-      return this
-    }
+    Builder consortiaExtra(boolean consortiaExtra) { return setParam('consortiaExtra', consortiaExtra) }
 
     /**
      * Enables or disables linked data features within the namespace.
@@ -258,30 +226,21 @@ class CreateNamespaceParameters implements Cloneable {
      * @param linkedData `true` to enable linked data features; `false` to disable.
      * @return Builder instance for method chaining.
      */
-    Builder linkedData(boolean linkedData) {
-      parameters.linkedData = linkedData
-      return this
-    }
+    Builder linkedData(boolean linkedData) { return setParam('linkedData', linkedData) }
 
     /**
      * Enables or disables split-files features within the namespace.
      * @param splitFiles `true` to enable split-files features; `false` to disable.
      * @return Builder instance for method chaining.
      */
-    Builder splitFiles(boolean splitFiles) {
-      parameters.splitFiles = splitFiles
-      return this
-    }
+    Builder splitFiles(boolean splitFiles) { return setParam('splitFiles', splitFiles) }
 
     /**
      * Enables or disables ECS_CCL feature within the namespace.
      * @param ecsCCL `true` to enable ECS_CCL features; `false` to disable.
      * @return Builder instance for method chaining.
      */
-    Builder ecsCCL(boolean ecsCCL) {
-      parameters.ecsCCL = ecsCCL
-      return this
-    }
+    Builder ecsCCL(boolean ecsCCL) { return setParam('ecsCCL', ecsCCL) }
 
     /**
      * Enables or disables read-write splitting for database access.
@@ -289,10 +248,7 @@ class CreateNamespaceParameters implements Cloneable {
      * @param rwSplit `true` to enable read-write splitting; `false` to disable.
      * @return Builder instance for method chaining.
      */
-    Builder rwSplit(boolean rwSplit) {
-      parameters.rwSplit = rwSplit
-      return this
-    }
+    Builder rwSplit(boolean rwSplit) { return setParam('rwSplit', rwSplit) }
 
     /**
      * Enables or disables the use of GreenMail for email testing.
@@ -300,10 +256,7 @@ class CreateNamespaceParameters implements Cloneable {
      * @param greenmail `true` to enable GreenMail; `false` to disable.
      * @return Builder instance for method chaining.
      */
-    Builder greenmail(boolean greenmail) {
-      parameters.greenmail = greenmail
-      return this
-    }
+    Builder greenmail(boolean greenmail) { return setParam('greenmail', greenmail) }
 
     /**
      * Enables or disables the mock server for testing without external dependencies.
@@ -311,62 +264,42 @@ class CreateNamespaceParameters implements Cloneable {
      * @param mockServer `true` to enable the mock server; `false` to disable.
      * @return Builder instance for method chaining.
      */
-    Builder mockServer(boolean mockServer) {
-      parameters.mockServer = mockServer
-      return this
-    }
+    Builder mockServer(boolean mockServer) { return setParam('mockServer', mockServer) }
 
     /**
      * Enables or disables refresh token rotation (RTR)
      * @param rtr `true` to enable RTR; `false` to disable.
      * @return Builder instance for method chaining.
      */
-    Builder rtr(boolean rtr) {
-      parameters.rtr = rtr
-      return this
-    }
+    Builder rtr(boolean rtr) { return setParam('rtr', rtr) }
 
     /**
      * Do or not marc-migrations
      * @param doMigrations `true` to do marc-migrations; `false` to skip.
      * @return Builder instance for method chaining.
      */
-    Builder doMarcMigrations(boolean doMigrations) {
-      parameters.marcMigrations = doMigrations
-      return this
-    }
+    Builder doMarcMigrations(boolean doMigrations) { return setParam('marcMigrations', doMigrations) }
 
     /**
      * Activate or not secure tenant
      * @param has `true` to activate security on tenant secureTenantId
      * @return Builder instance for method chaining.
      */
-    Builder hasSecureTenant(boolean has) {
-      parameters.hasSecureTenant = has
-      return this
-    }
+    Builder hasSecureTenant(boolean has) { return setParam('hasSecureTenant', has) }
 
     /**
      * Defines the id of the tenant to secure
      * @param id The id of the tenant to secure
      * @return Builder instance for method chaining.
      */
-    Builder secureTenantId(String id) {
-      parameters.secureTenantId = id
-      return this
-    }
+    Builder secureTenantId(String id) { return setParam('secureTenantId', id) }
 
     /**
      * Defines the type of environment to be used.
      * @param dataset `true` to enable BF like dataset; `false` to disable.
      * @return
      */
-
-    Builder dataset(boolean dataset) {
-      parameters.dataset = dataset
-      return this
-    }
-
+    Builder dataset(boolean dataset) { return setParam('dataset', dataset) }
 
     /**
      * Specifies the application names list for Eureka platform.
@@ -374,10 +307,7 @@ class CreateNamespaceParameters implements Cloneable {
      * @param list The list of application names to deploy.
      * @return Builder instance for method chaining.
      */
-    Builder applications(List<String> list) {
-      parameters.applications = list
-      return this
-    }
+    Builder applications(List<String> list) { return setParam('applications', list) }
 
     /**
      * Specifies the applications map for Eureka platform.
@@ -387,80 +317,56 @@ class CreateNamespaceParameters implements Cloneable {
      * @deprecated Use {@link #applications(List)} instead. Application versions are now resolved from FAR.
      */
     @Deprecated
-    Builder applications(Map map) {
-      parameters.applications = map.keySet().toList()
-      return this
-    }
+    Builder applications(Map map) { return setParam('applications', map.keySet().toList()) }
 
     /**
      * Specifies the type of PostgreSQL database to be used.
      * @param pgType The type of PostgreSQL deployment, e.g., "built-in" or a specific cloud provider's service.
      * @return Builder instance for method chaining.
      */
-    Builder pgType(String pgType) {
-      parameters.pgType = pgType
-      return this
-    }
+    Builder pgType(String pgType) { return setParam('pgType', pgType) }
 
     /**
      * Sets the version of the PostgreSQL database.
      * @param pgVersion The version number of PostgreSQL to use.
      * @return Builder instance for method chaining.
      */
-    Builder pgVersion(String pgVersion) {
-      parameters.pgVersion = pgVersion
-      return this
-    }
+    Builder pgVersion(String pgVersion) { return setParam('pgVersion', pgVersion) }
 
     /**
      * Defines the type of Kafka service to be used.
      * @param kafkaType The type of Kafka deployment, e.g., "built-in" or managed service.
      * @return Builder instance for method chaining.
      */
-    Builder kafkaType(String kafkaType) {
-      parameters.kafkaType = kafkaType
-      return this
-    }
+    Builder kafkaType(String kafkaType) { return setParam('kafkaType', kafkaType) }
 
     /**
      * Sets the type of OpenSearch service to be used.
      * @param opensearchType The deployment option for OpenSearch, such as "built-in" or a cloud service.
      * @return Builder instance for method chaining.
      */
-    Builder opensearchType(String opensearchType) {
-      parameters.opensearchType = opensearchType
-      return this
-    }
+    Builder opensearchType(String opensearchType) { return setParam('opensearchType', opensearchType) }
 
     /**
      * Determines the type of S3-compatible storage to be used.
      * @param s3Type The storage option for S3, indicating whether it's "built-in" or a specific provider.
      * @return Builder instance for method chaining.
-     */
-    Builder s3Type(String s3Type) {
-      parameters.s3Type = s3Type
-      return this
-    }
+    */
+    Builder s3Type(String s3Type) { return setParam('s3Type', s3Type) }
 
     /**
      * Identify if Cypress sanity check should be run.
      * @param runSanityCheck The option to run or skip cypress sanity check.
      * @return Builder instance for method chaining.
      */
-    Builder runSanityCheck(boolean runSanityCheck) {
-      parameters.runSanityCheck = runSanityCheck
-      return this
-    }
+    Builder runSanityCheck(boolean runSanityCheck) { return setParam('runSanityCheck', runSanityCheck) }
 
     /**
      * Lists members associated with the namespace, typically used for access control or resource sharing.
      * @param members A comma-separated list of members.
      * @return Builder instance for method chaining.
      */
-    Builder members(String members) {
-      parameters.members = members
-      return this
-    }
+    Builder members(String members) { return setParam('members', members) }
 
     /**
      * Marks the namespace as being solely for namespace management without deploying the full stack.
@@ -468,10 +374,7 @@ class CreateNamespaceParameters implements Cloneable {
      * @param namespaceOnly `true` to indicate only namespace creation/deletion; `false` for full deployment.
      * @return Builder instance for method chaining.
      */
-    Builder namespaceOnly(boolean namespaceOnly) {
-      parameters.namespaceOnly = namespaceOnly
-      return this
-    }
+    Builder namespaceOnly(boolean namespaceOnly) { return setParam('namespaceOnly', namespaceOnly) }
 
     @Deprecated
     /**
@@ -480,10 +383,7 @@ class CreateNamespaceParameters implements Cloneable {
      * @param worker The name of the Jenkins worker node.
      * @return Builder instance for method chaining.
      */
-    Builder worker(String worker) {
-      parameters.worker = worker
-      return this
-    }
+    Builder worker(String worker) { return setParam('worker', worker) }
 
     /**
      * Specifies whether UI  bundle should be build.
@@ -491,75 +391,65 @@ class CreateNamespaceParameters implements Cloneable {
      * @param uiBuild default true.
      * @return decision for UI.
      */
-    Builder uiBuild(boolean uiBuild) {
-      parameters.uiBuild = uiBuild
-      return this
-    }
+    Builder uiBuild(boolean uiBuild) { return setParam('uiBuild', uiBuild) }
 
-    Builder kongVersion(String kongVersion) {
-      parameters.kongVersion = kongVersion
-      return this
-    }
+    Builder kongVersion(String kongVersion) { return setParam('kongVersion', kongVersion) }
 
-    Builder keycloakVersion(String keycloakVersion) {
-      parameters.keycloakVersion = keycloakVersion
-      return this
-    }
+    Builder keycloakVersion(String keycloakVersion) { return setParam('keycloakVersion', keycloakVersion) }
 
-    Builder type(String type) {
-      parameters.type = type
-      return this
-    }
+    Builder type(String type) { return setParam('type', type) }
+
     /**
      * Specifies the snapshot of data migration to be used.
      * @param dmSnapshot The snapshot of data migration to use.
      * @return Builder instance for method chaining.
      */
-    Builder dmSnapshot(String dmSnapshot) {
-      parameters.dmSnapshot = dmSnapshot
-      return this
-    }
+    Builder dmSnapshot(String dmSnapshot) { return setParam('dmSnapshot', dmSnapshot) }
 
     /**
      * Specifies the name of the database backup to be used.
      * @param name The name of the database backup.
      * @return Builder instance for method chaining.
      */
-    Builder dbBackupName(String name) {
-      parameters.dbBackupName = name
-      return this
-    }
+    Builder dbBackupName(String name) { return setParam('dbBackupName', name) }
+
     /**
      * Specifies whether the namespace should be created with native support for SC (SideCar).
      * This is typically used for environments that require specific configurations for SideCar features.
      * @param scNative `true` to enable native support for SC; `false` otherwise.
      * @return Builder instance for method chaining.
      */
-    Builder scNative(boolean scNative) {
-      parameters.scNative = scNative
-      return this
-    }
+    Builder scNative(boolean scNative) { return setParam('scNative', scNative) }
 
-    Builder entitlementApproach(EntitlementApproach entitlementApproach) {
-      parameters.entitlementApproach = entitlementApproach
-      return this
-    }
+    Builder initParams(InitializeFromScratchParameters initParams) { return setParam('initParams', initParams) }
+
+    Builder releaseType(FolioRelease releaseType) { return setParam('releaseType', releaseType) }
+
+    Builder configExtensions(List<String> configExtensions) { return setParam('configExtensions', configExtensions) }
 
     /**
      * Specifies whether the consortia single UI feature should be enabled.
      * @param isConsortiaSingleUi
      * @return
      */
-    Builder isConsortiaSingleUi(boolean isConsortiaSingleUi){
-      parameters.isConsortiaSingleUi = isConsortiaSingleUi
-      return this
-    }
+    Builder isConsortiaSingleUi(boolean isConsortiaSingleUi) { return setParam('isConsortiaSingleUi', isConsortiaSingleUi) }
 
-    /**
-     * Builds the CreateNamespaceParameters instance.
-     * @return A new instance of CreateNamespaceParameters based on the builder settings.
-     */
-    CreateNamespaceParameters build() {
+    CreateNamespaceParameters build(def context = null) {
+      Map<String, Object> defaults = DependentParametersResolver.resolve(
+        parameters.clusterName, parameters.namespaceName, parameters.releaseType)
+
+      defaults.each { name, value ->
+        if (!modifiedFields.contains(name) && value != null && parameters.hasProperty(name)) {
+          parameters[name] = value
+        }
+      }
+
+      if (parameters.initParams.entitlementApproach == null && defaults.entitlementApproach != null)
+        parameters.initParams.entitlementApproach = defaults.entitlementApproach as EntitlementApproach
+
+      if (!modifiedFields.contains('applications') && !parameters.applications && parameters.platformBranch && context)
+        parameters.applications = context.folioDefault.getApplicationNamesFromPlatform(parameters.platformBranch)
+
       return parameters
     }
   }

--- a/src/org/folio/models/parameters/DependentParametersResolver.groovy
+++ b/src/org/folio/models/parameters/DependentParametersResolver.groovy
@@ -21,7 +21,7 @@ class DependentParametersResolver {
     // Release-driven
     result.entitlementApproach = (effectiveRelease == FolioRelease.SUNFLOWER) ? EntitlementApproach.CREATE : EntitlementApproach.STATE
     result.setBaseUrl = (effectiveRelease != FolioRelease.SUNFLOWER)
-    result.configExtensions = (effectiveRelease == FolioRelease.SUNFLOWER) ? ['sunflower-release'] : []
+    result.configExtensions = (effectiveRelease == FolioRelease.SUNFLOWER) ? ['sunflower'] : []
 
     // Cluster-driven
     result.platform = resolvePlatform(clusterName)

--- a/src/org/folio/models/parameters/DependentParametersResolver.groovy
+++ b/src/org/folio/models/parameters/DependentParametersResolver.groovy
@@ -13,15 +13,20 @@ import org.folio.rest_v2.PlatformType
  */
 class DependentParametersResolver {
 
-  static Map<String, Object> resolve(String clusterName, String namespaceName, FolioRelease releaseType) {
+  static Map<String, Object> resolve(String clusterName, String namespaceName, String platformBranch, def context = null) {
     Map<String, Object> result = [:]
 
-    FolioRelease effectiveRelease = releaseType ?: FolioRelease.SNAPSHOT
+    FolioRelease releaseType = FolioRelease.fromPlatformBranch(context, platformBranch)
+    result.releaseType = releaseType
+
+    if (context && platformBranch) {
+      result.applications = context.folioDefault.getApplicationNamesFromPlatform(platformBranch)
+    }
 
     // Release-driven
-    result.entitlementApproach = (effectiveRelease == FolioRelease.SUNFLOWER) ? EntitlementApproach.CREATE : EntitlementApproach.STATE
-    result.setBaseUrl = (effectiveRelease != FolioRelease.SUNFLOWER)
-    result.configExtensions = (effectiveRelease == FolioRelease.SUNFLOWER) ? ['sunflower'] : []
+    result.entitlementApproach = (releaseType == FolioRelease.SUNFLOWER) ? EntitlementApproach.CREATE : EntitlementApproach.STATE
+    result.setBaseUrl = (releaseType != FolioRelease.SUNFLOWER)
+    result.configExtensions = (releaseType == FolioRelease.SUNFLOWER) ? ['sunflower'] : []
 
     // Cluster-driven
     result.platform = resolvePlatform(clusterName)

--- a/src/org/folio/models/parameters/DependentParametersResolver.groovy
+++ b/src/org/folio/models/parameters/DependentParametersResolver.groovy
@@ -1,0 +1,87 @@
+package org.folio.models.parameters
+
+import org.folio.Constants
+import org.folio.rest_v2.EntitlementApproach
+import org.folio.rest_v2.FolioRelease
+import org.folio.rest_v2.PlatformType
+
+/**
+ * Single home for dependent-parameter derivation: given cluster, namespace, and release,
+ * produce a Map of default values for linked parameters. Callers merge this into their
+ * own parameter objects. All rules (release-driven, cluster-driven, namespace-driven)
+ * live here so they can evolve without touching CreateNamespaceParameters or the UI.
+ */
+class DependentParametersResolver {
+
+  static Map<String, Object> resolve(String clusterName, String namespaceName, FolioRelease releaseType) {
+    Map<String, Object> result = [:]
+
+    FolioRelease effectiveRelease = releaseType ?: FolioRelease.SNAPSHOT
+
+    // Release-driven
+    result.entitlementApproach = (effectiveRelease == FolioRelease.SUNFLOWER) ? EntitlementApproach.CREATE : EntitlementApproach.STATE
+    result.setBaseUrl = (effectiveRelease != FolioRelease.SUNFLOWER)
+    result.configExtensions = (effectiveRelease == FolioRelease.SUNFLOWER) ? ['sunflower-release'] : []
+
+    // Cluster-driven
+    result.platform = resolvePlatform(clusterName)
+    result.configType = resolveConfigType(clusterName)
+    result.pgType = resolveInfraType(clusterName)
+    result.kafkaType = resolveInfraType(clusterName)
+    result.s3Type = resolveInfraType(clusterName)
+
+    // Cluster + namespace combined
+    result.dataset = resolveDataset(clusterName, namespaceName)
+    result.members = resolveMembers(clusterName, namespaceName)
+
+    Map overrides = NAMESPACE_OVERRIDES.get(clusterName)?.get(namespaceName) ?: [:]
+    result.putAll(overrides)
+
+    return result
+  }
+
+  private static final Map NAMESPACE_OVERRIDES = [
+    'folio-etesting': [
+      'sprint': [pgType: 'aws', kafkaType: 'aws', s3Type: 'aws', dataset: true]
+    ]
+  ]
+
+  private static PlatformType resolvePlatform(String clusterName) {
+    if (!clusterName) return PlatformType.EUREKA
+    Map platformClusters = Constants.AWS_EKS_PLATFORM_CLUSTERS()
+    if (platformClusters[PlatformType.EUREKA.name()]?.contains(clusterName)) return PlatformType.EUREKA
+    if (platformClusters[PlatformType.OKAPI.name()]?.contains(clusterName)) return PlatformType.OKAPI
+    return PlatformType.EUREKA
+  }
+
+  private static String resolveConfigType(String clusterName) {
+    if (!clusterName) return 'development'
+    if (clusterName.contains('testing')) return 'testing'
+    if (clusterName.contains('perf')) return 'performance'
+    return 'development'
+  }
+
+  private static String resolveInfraType(String clusterName) {
+    // Performance clusters use AWS-managed services; everything else defaults to built-in.
+    if (clusterName == 'folio-perf' || clusterName == 'folio-eperf') return 'aws'
+    return 'built-in'
+  }
+
+  private static boolean resolveDataset(String clusterName, String namespaceName) {
+    if (!clusterName || !namespaceName) return false
+    boolean isPerfCluster = (clusterName == 'folio-perf' || clusterName == 'folio-eperf')
+    boolean isBugfestNs = namespaceName.toLowerCase().contains('bugfest')
+    return isPerfCluster && isBugfestNs
+  }
+
+  private static final List<String> SHARED_NAMESPACES = ['sprint', 'snapshot', 'snapshot2']
+  private static final List<String> EUREKA_CLUSTERS = ['folio-etesting', 'folio-edev', 'folio-eperf']
+  private static final String SHARED_ENV_MEMBERS = 'thunderjet,folijet,spitfire,vega,thor,Eureka,volaris,corsair,Bama,Aggies,Dreamliner,Leipzig,firebird,dojo,erm'
+
+  private static String resolveMembers(String clusterName, String namespaceName) {
+    if (!clusterName || !namespaceName) return ''
+    if (EUREKA_CLUSTERS.contains(clusterName) && SHARED_NAMESPACES.contains(namespaceName))
+      return SHARED_ENV_MEMBERS
+    return Constants.ENVS_MEMBERS_LIST.getOrDefault(namespaceName, '') as String
+  }
+}

--- a/src/org/folio/models/parameters/InitializeFromScratchParameters.groovy
+++ b/src/org/folio/models/parameters/InitializeFromScratchParameters.groovy
@@ -1,0 +1,32 @@
+package org.folio.models.parameters
+
+import org.folio.rest_v2.EntitlementApproach
+
+/**
+ * Carries per-run initialization settings consumed by Eureka.initializeFromScratch.
+ * Values are set either explicitly (e.g. from the Jenkins UI) or derived via
+ * {@link DependentParametersResolver}. Nullable fields indicate "not explicitly
+ * set yet" so downstream layers can fill in the authoritative default.
+ */
+class InitializeFromScratchParameters {
+
+  EntitlementApproach entitlementApproach
+  boolean setBaseUrl = true
+  boolean migrate = false
+
+  InitializeFromScratchParameters() {}
+
+  InitializeFromScratchParameters(EntitlementApproach entitlementApproach) {
+    this.entitlementApproach = entitlementApproach
+  }
+
+  InitializeFromScratchParameters withSetBaseUrl(boolean setBaseUrl) {
+    this.setBaseUrl = setBaseUrl
+    return this
+  }
+
+  InitializeFromScratchParameters withMigrate(boolean migrate) {
+    this.migrate = migrate
+    return this
+  }
+}

--- a/src/org/folio/models/parameters/InitializeFromScratchParameters.groovy
+++ b/src/org/folio/models/parameters/InitializeFromScratchParameters.groovy
@@ -2,22 +2,15 @@ package org.folio.models.parameters
 
 import org.folio.rest_v2.EntitlementApproach
 
-/**
- * Carries per-run initialization settings consumed by Eureka.initializeFromScratch.
- * Values are set either explicitly (e.g. from the Jenkins UI) or derived via
- * {@link DependentParametersResolver}. Nullable fields indicate "not explicitly
- * set yet" so downstream layers can fill in the authoritative default.
- */
 class InitializeFromScratchParameters {
 
   EntitlementApproach entitlementApproach
   boolean setBaseUrl = true
   boolean migrate = false
 
-  InitializeFromScratchParameters() {}
-
-  InitializeFromScratchParameters(EntitlementApproach entitlementApproach) {
+  InitializeFromScratchParameters withEntitlementApproach(EntitlementApproach entitlementApproach) {
     this.entitlementApproach = entitlementApproach
+    return this
   }
 
   InitializeFromScratchParameters withSetBaseUrl(boolean setBaseUrl) {

--- a/src/org/folio/rest_v2/FolioRelease.groovy
+++ b/src/org/folio/rest_v2/FolioRelease.groovy
@@ -21,4 +21,10 @@ enum FolioRelease {
     }
     return SNAPSHOT
   }
+
+  static FolioRelease fromPlatformBranch(def context, String platformBranch) {
+    if (!context || !platformBranch) return SNAPSHOT
+    Map descriptor = context.folioDefault.getPlatformDescriptor(platformBranch)
+    return fromPlatformVersion(descriptor?.version as String)
+  }
 }

--- a/src/org/folio/rest_v2/FolioRelease.groovy
+++ b/src/org/folio/rest_v2/FolioRelease.groovy
@@ -1,0 +1,24 @@
+package org.folio.rest_v2
+
+enum FolioRelease {
+
+  SUNFLOWER('R1-2025'),
+  TRILLIUM('R1-2026'),
+  SNAPSHOT(null)
+
+  final String versionPrefix
+
+  FolioRelease(String versionPrefix) {
+    this.versionPrefix = versionPrefix
+  }
+
+  static FolioRelease fromPlatformVersion(String version) {
+    if (!version) return SNAPSHOT
+    def matcher = version =~ /^(R\d+-\d{4})/
+    if (matcher.find()) {
+      String prefix = matcher.group(1)
+      return values().find { it.versionPrefix == prefix } ?: SNAPSHOT
+    }
+    return SNAPSHOT
+  }
+}

--- a/src/org/folio/rest_v2/eureka/Eureka.groovy
+++ b/src/org/folio/rest_v2/eureka/Eureka.groovy
@@ -7,6 +7,7 @@ import org.folio.models.application.Application
 import org.folio.models.application.ApplicationList
 import org.folio.models.module.EurekaModule
 import org.folio.models.module.FolioModule
+import org.folio.models.parameters.InitializeFromScratchParameters
 import org.folio.rest_v2.EntitlementApproach
 import org.folio.rest_v2.eureka.kong.*
 
@@ -31,7 +32,7 @@ class Eureka extends Base {
   }
 
   Eureka createTenantFlow(EurekaTenant tenant, String cluster, String namespace,
-                           boolean migrate = false, EntitlementApproach entitlementApproach = EntitlementApproach.STATE) {
+                          InitializeFromScratchParameters params) {
     EurekaTenant createdTenant = Tenants.get(kong).createTenant(tenant)
 
     tenant.withUUID(createdTenant.getUuid())
@@ -46,7 +47,7 @@ class Eureka extends Base {
 
     kong.keycloak.defineTTL(tenant.tenantId, 600)
 
-    if (entitlementApproach == EntitlementApproach.CREATE) {
+    if (params.entitlementApproach == EntitlementApproach.CREATE) {
       ApplicationList entitledApps = Tenants.get(kong).getEnabledApplications(tenant)
       Tenants.get(kong).enableApplications(
         tenant,
@@ -68,23 +69,27 @@ class Eureka extends Base {
       , new Role(name: "adminRole", desc: "Admin role")
       , Permissions.get(kong).getCapabilitiesId(tenant)
       , Permissions.get(kong).getCapabilitySetsId(tenant)
-      , migrate)
+      , params.migrate)
 
-    configureTenant(tenant)
+    configureTenant(tenant, params)
 
     return this
   }
 
-  Eureka configureTenant(EurekaTenant tenant){
-    Configurations.get(kong)
-      .setSmtp(tenant)
+  Eureka configureTenant(EurekaTenant tenant, InitializeFromScratchParameters params) {
+    Configurations configs = Configurations.get(kong)
+    configs.setSmtp(tenant)
       .setResetPasswordLink(tenant)
 
-    if(tenant.getModules().getModuleByName('mod-copycat'))
-      Configurations.get(kong).setWorldcat(tenant)
+    if (params.setBaseUrl) {
+      configs.setBaseUrl(tenant)
+    }
 
-    if(tenant.getModules().getModuleByName('mod-kb-ebsco-java'))
-      Configurations.get(kong).setRmapiConfig(tenant)
+    if (tenant.getModules().getModuleByName('mod-copycat'))
+      configs.setWorldcat(tenant)
+
+    if (tenant.getModules().getModuleByName('mod-kb-ebsco-java'))
+      configs.setRmapiConfig(tenant)
 
     return this
   }
@@ -224,11 +229,10 @@ class Eureka extends Base {
     return this
   }
 
-  Eureka initializeFromScratch(Map<String, EurekaTenant> tenants, String cluster, String namespace
-                               , boolean enableConsortia, boolean migrate = false
-                               , EntitlementApproach entitlementApproach = EntitlementApproach.STATE) {
+  Eureka initializeFromScratch(Map<String, EurekaTenant> tenants, String cluster, String namespace,
+                               boolean enableConsortia, InitializeFromScratchParameters params) {
     tenants.each { tenantId, tenant ->
-      createTenantFlow(tenant, cluster, namespace, migrate, entitlementApproach)
+      createTenantFlow(tenant, cluster, namespace, params)
     }
 
     if (enableConsortia)

--- a/src/org/folio/rest_v2/eureka/kong/Configurations.groovy
+++ b/src/org/folio/rest_v2/eureka/kong/Configurations.groovy
@@ -170,6 +170,19 @@ class Configurations extends Kong {
       }
     }
 
+    return this
+  }
+
+  /**
+   * Sets the base-url for the specified tenant via PUT /base-url endpoint.
+   * This endpoint was introduced after the Sunflower release and should not be called for it.
+   *
+   * @param tenant The tenant for which to set the base-url.
+   */
+  Configurations setBaseUrl(EurekaTenant tenant) {
+    if (!tenant.okapiConfig?.resetPasswordLink)
+      return this
+
     logger.info("Set base-url on tenant ${tenant.tenantId} with ${tenant.uuid}...")
 
     Map<String, String> headers = getTenantHttpHeaders(tenant)

--- a/vars/folioNamespaceCreateEureka.groovy
+++ b/vars/folioNamespaceCreateEureka.groovy
@@ -5,6 +5,7 @@ import org.folio.models.*
 import org.folio.models.application.ApplicationList
 import org.folio.models.module.FolioModule
 import org.folio.models.parameters.CreateNamespaceParameters
+import org.folio.rest_v2.FolioRelease
 import org.folio.rest_v2.PlatformType
 import org.folio.rest_v2.eureka.Eureka
 import org.folio.rest_v2.eureka.kong.Applications
@@ -67,7 +68,7 @@ void call(CreateNamespaceParameters args) {
       logger.info("Using Kong version: ${kongVersion}, Keycloak version: ${keycloakVersion}")
 
       def defaultTenantId = args.dataset ? 'fs09000000' : 'diku'
-      boolean isRelease = args.platformBranch ==~ /^R\d-\d{4}.*/
+      boolean isRelease = (args.releaseType != null && args.releaseType != FolioRelease.SNAPSHOT)
       String commitHash = common.getLastCommitHash('platform-lsp', args.platformBranch)
       // TODO: Refactor UI build to use platform-lsp instead of platform-complete
       String uiCommitHash = common.getLastCommitHash('platform-complete', args.folioBranch)
@@ -175,6 +176,7 @@ void call(CreateNamespaceParameters args) {
       namespace.setEnableRwSplit(args.rwSplit)
       namespace.setEnableRtr(args.rtr)
       namespace.setEnableECS_CCL(args.ecsCCL)
+      namespace.setConfigExtensions(args.configExtensions ?: [])
       namespace.addDeploymentConfig(folioTools.getPipelineBranch())
 
       namespace.addTenant(
@@ -370,8 +372,7 @@ void call(CreateNamespaceParameters args) {
             , namespace.getClusterName()
             , namespace.getNamespaceName()
             , namespace.getEnableConsortia()
-            , false // Set this option true, when users & groups migration is required.
-            , args.entitlementApproach
+            , args.initParams
           )
         }
       }

--- a/vars/folioParameters.groovy
+++ b/vars/folioParameters.groovy
@@ -107,7 +107,7 @@ def platform(PlatformType defaultValue = null, String paramName = 'PLATFORM') {
 }
 
 def platformFromCluster(String paramName = 'PLATFORM', String reference = 'CLUSTER') {
-  return _paramExtendedSingleSelect(paramName, reference, folioStringScripts.getPlatformFromCluster(),
+  return _paramExtendedSingleSelect(paramName, reference, folioStringScripts.getPlatformFromCluster(reference),
     'Platform type (auto-derived from cluster)')
 }
 

--- a/vars/folioParameters.groovy
+++ b/vars/folioParameters.groovy
@@ -106,6 +106,11 @@ def platform(PlatformType defaultValue = null, String paramName = 'PLATFORM') {
   return _paramChoice(paramName, values, 'Select FOLIO platform')
 }
 
+def platformFromCluster(String paramName = 'PLATFORM', String reference = 'CLUSTER') {
+  return _paramExtendedSingleSelect(paramName, reference, folioStringScripts.getPlatformFromCluster(),
+    'Platform type (auto-derived from cluster)')
+}
+
 def applicationsFromPlatform(String paramName = 'APPLICATIONS', String reference = 'PLATFORM_BRANCH') {
   return _paramExtendedCheckboxSelect(paramName, reference, folioStringScripts.getApplicationsFromPlatformDescriptor(reference), 'Select env applications', false)
 }

--- a/vars/folioStringScripts.groovy
+++ b/vars/folioStringScripts.groovy
@@ -9,6 +9,15 @@ ${Constants.AWS_EKS_CLUSTERS_LIST.inspect()}
 """.stripIndent()
 }
 
+static String getPlatformFromCluster() {
+  Map<String, String> clusterPlatform = Constants.AWS_EKS_CLUSTERS
+    .collectEntries { [(it.name): it.platform[0].name()] }
+  return """def mapping = ${clusterPlatform.inspect()}
+def platform = mapping[CLUSTER] ?: 'EUREKA'
+return ["\${platform}:selected"]
+""".stripIndent()
+}
+
 static String getNamespaces() {
   return """def namespacesList = ${Constants.AWS_EKS_NAMESPACE_MAPPING.inspect()}
 return namespacesList[CLUSTER]

--- a/vars/folioStringScripts.groovy
+++ b/vars/folioStringScripts.groovy
@@ -9,12 +9,13 @@ ${Constants.AWS_EKS_CLUSTERS_LIST.inspect()}
 """.stripIndent()
 }
 
-static String getPlatformFromCluster() {
+static String getPlatformFromCluster(String cluster) {
   Map<String, String> clusterPlatform = Constants.AWS_EKS_CLUSTERS
     .collectEntries { [(it.name): it.platform[0].name()] }
-  return """def mapping = ${clusterPlatform.inspect()}
-def platform = mapping[CLUSTER] ?: 'EUREKA'
-return ["\${platform}:selected"]
+
+  return """
+String platform = ${clusterPlatform.inspect()}[${cluster}] ?: 'EUREKA'
+return [platform]
 """.stripIndent()
 }
 

--- a/vars/folioTriggerJob.groovy
+++ b/vars/folioTriggerJob.groovy
@@ -46,7 +46,8 @@ def createNamespaceFromBranch(String jobName, CreateNamespaceParameters namespac
       string(name: 'OPENSEARCH', value: namespaceParams.getOpensearchType()),
       string(name: 'S3_BUCKET', value: namespaceParams.getS3Type()),
       booleanParam(name: 'SC_NATIVE', value: namespaceParams.getScNative()),
-      string(name: 'ENTITLEMENT_APPROACH', value: namespaceParams.getEntitlementApproach().name()),
+      string(name: 'ENTITLEMENT_APPROACH', value: namespaceParams.getInitParams().getEntitlementApproach()?.name() ?: ''),
+      booleanParam(name: 'SET_BASE_URL', value: namespaceParams.getInitParams().getSetBaseUrl()),
       booleanParam(name: 'RUN_SANITY_CHECK', value: namespaceParams.getRunSanityCheck()),
       string(name: 'MEMBERS', value: namespaceParams.getMembers())]
   return jobResult


### PR DESCRIPTION
Release-aware pipeline configuration for Eureka namespace creation. Centralizes all derivation logic (release type, infra defaults, members, applications, helm overlays, entitlement approach, base-url behavior) so Jenkinsfiles only need to specify cluster/namespace/branch — the rest is derived from `platform-descriptor.json`'s `version` field plus cluster/namespace heuristics.

## Architecture

- **`FolioRelease`** (new) — value-object enum mapping version-prefix → release. Adds `fromPlatformBranch(context, branch)` that fetches `platform-descriptor.json` and derives the release from `version`.
- **`DependentParametersResolver`** (new) — single home for all derivation: release-driven (entitlement approach, setBaseUrl, configExtensions), cluster-driven (platform, configType, infra types), namespace-driven (members, dataset). Returns a `Map<String, Object>` of defaults.
- **`InitializeFromScratchParameters`** (new) — carries `entitlementApproach`, `setBaseUrl`, `migrate` for `Eureka.initializeFromScratch`. Uniform `with*` setters.
- **`CreateNamespaceParameters.Builder.build(context)`** — runs the resolver, applies map defaults via generic loop. Universal `setParam(name, value)` tracks modified fields so explicit setters override resolver defaults. Auto-fills `applications` from the platform descriptor when `context` is passed.
- **`EurekaNamespace.addDeploymentConfig`** — iterates `configExtensions` and merges each helm feature YAML.
- **`RancherNamespace.mergeMaps`** — fixed name-keyed list merge so feature YAMLs can override existing `extraEnvVars` entries (prevents duplicate `name` keys).
- **`Configurations.setBaseUrl`** — extracted from `setResetPasswordLink`; called conditionally based on `params.setBaseUrl` (skipped for Sunflower).

## Pipeline changes

**`createNamespaceFromBranch/Jenkinsfile`** (power-user):
- Added `SET_BASE_URL` boolean param (Eureka-only).
- `entitlementApproach` and other derivable fields now optional — Builder fills them via resolver.

**`createNamespace/Jenkinsfile`** (rewritten as minimal):
- Inputs: cluster, namespace, branch, consortia. Everything else derived.
- Hidden `PLATFORM` reactive param auto-derived from cluster via new `folioParameters.platformFromCluster()`.
- Routes to `createNamespaceFromBranch` via `folioTriggerJob`.
- New flow: checks if namespace exists → asks user via Jenkins UI input prompt → triggers delete then create.
- Daily cron at 20:00 for `folio-edev:eureka` with hidden `FORCE_DELETE_IF_EXISTS=true` (skips the prompt for unattended runs).

**`recreateTeamNamespace/Jenkinsfile`** — deprecated. Aborts with a message pointing users to `createNamespace` (use `FORCE_DELETE_IF_EXISTS=true` for unattended runs).

## Helm

- New `resources/helm/features/sunflower.yaml` overlay sets `VALIDATION_INTERFACE_COLLECTOR_MODE=combined` for `mgr-tenant-entitlements` (Sunflower-only).
- Resolver returns `configExtensions: ['sunflower']` for Sunflower; `EurekaNamespace.addDeploymentConfig` applies it.

## Defaults driven by cluster/namespace

- `folio-perf` / `folio-eperf` → `aws` infra; everything else → `built-in`.
- Cluster name → `configType` (`*testing` → `testing`, `*perf` → `performance`, else `development`).
- Eureka clusters + shared namespaces (`sprint`, `snapshot`, `snapshot2`) → curated team members list.
- Performance cluster + `bugfest`-named namespace → `dataset: true`.
- `folio-etesting:sprint` → all-AWS infra + `dataset: true` via `NAMESPACE_OVERRIDES`.