### PR TITLE
RANCHER-2888 Switch provisioning and update of folio-etesting-sprint from snapshot to R1-2026 (Trillium) versions

### DIFF
--- a/pipelines/folioRancher/folioScheduledProvisioning/updateSprintTestingEureka/Jenkinsfile
+++ b/pipelines/folioRancher/folioScheduledProvisioning/updateSprintTestingEureka/Jenkinsfile
@@ -39,11 +39,12 @@ properties([
     , folioParameters.hideParameters(['IS_CRON_JOB'])
 
   ]),
-  pipelineTriggers([
-    parameterizedCron('''
-      H 3 * * 1,2,3,4,5 %PLATFORM=EUREKA;CLUSTER=folio-etesting;NAMESPACE=sprint;CONFIG_TYPE=testing;DB_BACKUP_NAME=folio-bugfest-sunflower-24-02-2026;MARC_MIGRATIONS=true;TYPE=update;IS_CRON_JOB=true
-      H 0 * * 3 %PLATFORM=EUREKA;CLUSTER=folio-etesting;NAMESPACE=sprint;CONFIG_TYPE=testing;DB_BACKUP_NAME=folio-bugfest-sunflower-24-02-2026;MARC_MIGRATIONS=true;TYPE=full;IS_CRON_JOB=true
-    ''')])
+//  TODO: Uncomment after Trillium verification ends. ETA - Sprint 242 or 243. Only after notification from @OleksiiPetrenko.
+//  pipelineTriggers([
+//    parameterizedCron('''
+//      H 3 * * 1,2,3,4,5 %PLATFORM=EUREKA;CLUSTER=folio-etesting;NAMESPACE=sprint;CONFIG_TYPE=testing;DB_BACKUP_NAME=folio-bugfest-sunflower-24-02-2026;MARC_MIGRATIONS=true;TYPE=update;IS_CRON_JOB=true
+//      H 0 * * 3 %PLATFORM=EUREKA;CLUSTER=folio-etesting;NAMESPACE=sprint;CONFIG_TYPE=testing;DB_BACKUP_NAME=folio-bugfest-sunflower-24-02-2026;MARC_MIGRATIONS=true;TYPE=full;IS_CRON_JOB=true
+//    ''')])
 ])
 
 


### PR DESCRIPTION
Comment out the pipelineTriggers block in the Jenkinsfile to stop scheduled runs during Trillium verification. 
Added a TODO note indicating to re-enable the cron jobs after verification ends (ETA Sprint 242 or 243) and to wait for notification from @OleksiiPetrenko. 
The existing cron schedules and parameters are preserved in the commented block for easy restoration.