### PR TITLE
RANCHER-2952-fix. Handle missing SSM parameter gracefully in folioHashCommitCheck function

### DIFF
--- a/vars/folioHashCommitCheck.groovy
+++ b/vars/folioHashCommitCheck.groovy
@@ -108,17 +108,20 @@ def hasRepoShaChanged(String org, String repo, String branch = 'master', String 
 
     String previousSha = null
     awscli.withAwsClient {
-        previousSha = awscli.getSsmParameterValue(awsRegion, ssmParameterName)
+        try {
+            previousSha = awscli.getSsmParameterValue(awsRegion, ssmParameterName)
+        } catch (ignored) {
+            previousSha = null
+        }
     }
 
     if (previousSha == latestSha) {
         return false
-    } else {
-        awscli.withAwsClient {
-            awscli.updateSsmParameter(awsRegion, ssmParameterName, latestSha)
-        }
-        return true
     }
+    awscli.withAwsClient {
+        awscli.updateSsmParameter(awsRegion, ssmParameterName, latestSha)
+    }
+    return true
 }
 
 def hasFolioIntegrationTestsShaChanged(String branch = 'master', String ssmParameterName = 'FOLIO_INTEGRATION_TESTS_SHA') {


### PR DESCRIPTION
## Summary

- `folioQualityGates` build #3132 aborted in the `Check Changes` stage with `hudson.AbortException: script returned exit code 254` because `aws ssm get-parameter --name FOLIO_INTEGRATION_TESTS_SHA` returned `ParameterNotFound` and the call was not wrapped in try/catch.
- `vars/folioHashCommitCheck.groovy` `hasRepoShaChanged` (introduced in #1292 / RANCHER-2952) reads the previous SHA via `awscli.getSsmParameterValue` without protection, so a missing SSM parameter propagates as a fatal error instead of falling through to the seed-and-return-`true` branch already implemented below it.
- This affected both `hasFolioIntegrationTestsShaChanged` (`FOLIO_INTEGRATION_TESTS_SHA`) and `hasStripesTestingShaChanged` (`STRIPES_TESTING_SHA`). The parameters had never been created in SSM — they were meant to be seeded on first run by the very same function — and the unguarded `sh` step prevented that seeding from ever happening.

## Root cause

The intended contract (visible in `isInstallJsonChanged` and `getPreviousBuildSha`) is that a missing previous SHA means *changed → proceed*. `hasRepoShaChanged` did not honor that contract: AWS CLI exits 254 on `ParameterNotFound`, the `sh` step throws `hudson.AbortException`, and the unprotected call aborts the whole pipeline before reaching the `updateSsmParameter` branch that would have created the parameter.

`deleteNamespace` was ruled out as a cause: `folioTools.deleteSSMParameters` filters by `${cluster}-${namespace}_` (e.g. `folio-etesting-cicypress_`), which does not match the global `FOLIO_INTEGRATION_TESTS_SHA` / `STRIPES_TESTING_SHA` names.

## Fix

`vars/folioHashCommitCheck.groovy` — wrap the SSM read in `hasRepoShaChanged` with try/catch so a missing parameter resolves to `previousSha = null`. The existing logic then takes the "not equal → updateSsmParameter → return true" branch, which seeds the parameter on first run and lets the pipeline proceed. Same idiom already used by `getPreviousBuildSha`.

Behavior:
- First run with missing SSM parameter → seeds it, returns `true` (proceed).
- Subsequent runs with no upstream changes → parameter matches, returns `false` (skip).
- Happy path unchanged.

Fixes both `hasFolioIntegrationTestsShaChanged` and `hasStripesTestingShaChanged` in one place.
