### PR TITLE
RANCHER-2952-fix. Update Jenkinsfile and GitHubClient for enhanced commit diff handling.

### DIFF
--- a/pipelines/folioRancher/folioScheduledTesting/folioQualityGates/Jenkinsfile
+++ b/pipelines/folioRancher/folioScheduledTesting/folioQualityGates/Jenkinsfile
@@ -147,7 +147,7 @@ ansiColor('xterm') {
     podTemplates.rancherAgent {
       stage('[AWS] Update ssm') {
         if (currentBuildSha) {
-          folioHashCommitCheck.updateBuildSha(currentBuildSha)
+          folioHashCommitCheck.updateBuildSha(currentBuildSha, 'platform-lsp')
         }
       }
 

--- a/src/org/folio/utilities/GitHubClient.groovy
+++ b/src/org/folio/utilities/GitHubClient.groovy
@@ -73,21 +73,21 @@ class GitHubClient {
     }
   }
 
-  List getTwoCommitsDiff(String previousSha, String currentSha, String repository) {
+  Map getTwoCommitsDiff(String previousSha, String currentSha, String repository) {
     String url = "${Constants.FOLIO_GITHUB_REPOS_URL}/${repository}/compare/${previousSha}...${currentSha}"
     Map<String, String> headers = authorizedHeaders()
 
     try {
       def response = restClient.get(url, headers)
       if (response.responseCode >= 200 && response.responseCode < 300) {
-        return response.body ?: []
+        return response.body instanceof Map ? response.body : [:]
       } else {
         logger.warning("GitHub API returned ${response.responseCode} for commit diff: ${url}")
-        return []
+        return [:]
       }
     } catch (Exception e) {
       logger.warning("Failed to get commit diff for ${repository} ${previousSha}...${currentSha}: ${e.getMessage()}")
-      return []
+      return [:]
     }
   }
 


### PR DESCRIPTION
## Summary

Follow-up to #1299. After the missing-SSM-parameter abort was fixed, build #3136 surfaced two latent bugs that the previous failure had been hiding:

- `src/org/folio/utilities/GitHubClient.groovy` — `getTwoCommitsDiff` was declared `List` but on success returned the GitHub `/compare` JSON object (a Map), and on failure returned `[]` (an ArrayList). Its only live caller (`vars/folioHashCommitCheck.groovy:91`) does `Map commitsDiff = ...` and accesses `.files`, which works fine for the success path but throws `GroovyCastException: Cannot cast object '[]' with class 'java.util.ArrayList' to class 'java.util.Map'` on any non-2xx response. The wrong return-type annotation has existed since the method was introduced (`a45ef53b`, Aug 2024); the `[]` fallback added in `246871ba` armed the latent mismatch.
- `pipelines/folioRancher/folioScheduledTesting/folioQualityGates/Jenkinsfile:150` — `folioHashCommitCheck.updateBuildSha(currentBuildSha)` was called without a `name` argument, so it defaulted to `'Hash-Commit'` and only ever wrote that legacy parameter. The read side (`getPreviousPlatformLspSha` → `getPreviousBuildSha('platform-lsp')`) does include `PLATFORM_LSP_SHA` in its candidate chain. RANCHER-2952 migrated the read side to platform-lsp but not the write side — so a stale `PLATFORM_LSP_SHA = "test"` in SSM was read every run and never overwritten, which made the GitHub `compare/test...<currentSha>` call 404 and triggered the cast bug above.

## Fix

- `src/org/folio/utilities/GitHubClient.groovy` — `getTwoCommitsDiff` now declares and returns `Map` consistently. Failure paths return `[:]`; the success path guards with `response.body instanceof Map ? response.body : [:]`. Caller's `commitsDiff?.files?.any { ... } ?: false` short-circuits cleanly to `false` for an empty-Map fallback — no exception, no spurious "changed" trigger.
- `pipelines/folioRancher/folioScheduledTesting/folioQualityGates/Jenkinsfile` — `updateBuildSha(currentBuildSha, 'platform-lsp')` now targets the same parameter family the read side reads from. `updateBuildSha`'s candidate-fallback logic (`vars/folioHashCommitCheck.groovy:40-71`) walks `['platform-lsp', 'Hash-Commit-platform-lsp', 'PLATFORM_LSP_SHA', 'Hash-Commit']`, finds the existing `PLATFORM_LSP_SHA`, and overwrites it with the real SHA. From the next successful run onward, `previousSha` is a valid platform-lsp SHA and the diff comparison works correctly.

No SSM cleanup required — the first successful build that reaches the `[AWS] Update ssm` stage will overwrite `PLATFORM_LSP_SHA = "test"` automatically. No changes needed in `folioChangeLog.groovy` (it no longer calls `getTwoCommitsDiff`; was removed in `80678333` / `8bbe0f59` when changelog switched to platform-lsp).