### PR TITLE
CIRC-2603. Fix ECS BFF flag using explicit consortia and ecsCCL config instead of tenant ID prefix heuristic

### DIFF
--- a/vars/folioNamespaceCreateEureka.groovy
+++ b/vars/folioNamespaceCreateEureka.groovy
@@ -387,8 +387,11 @@ void call(CreateNamespaceParameters args) {
           namespace.getTenants().each { tenantId, tenant ->
             if (tenant.getTenantUi()) {
               branches[tenantId] = {
-                boolean isECSBff = tenant.tenantId.startsWith("c")
-                folioUI.buildAndDeploy(namespace, tenant, isECSBff)
+                println("Is Consortia: ${tenant.getTenantUi().getIsConsortia()}")
+                println("ECS CCL enabled: ${args.ecsCCL}")
+                boolean isEcsBff = tenant.getTenantUi().getIsConsortia() && args.ecsCCL
+                println("Is ECS BFF: ${isEcsBff}")
+                folioUI.buildAndDeploy(namespace, tenant, isEcsBff)
               }
             }
           }


### PR DESCRIPTION
## Summary

- Replace brittle `tenantId.startsWith("c")` heuristic for ECS BFF detection with an explicit check
- `isEcsBff` is now `true` only when `tenant.getTenantUi().getIsConsortia() == true` AND `args.ecsCCL == true`
- Added diagnostic `println` statements to log consortia and ecsCCL values during UI deploy

## Test plan

- [x] Deploy a namespace with `ecsCCL = true` and a consortia tenant — verify ECS BFF mode is activated
- [x] Deploy a namespace with `ecsCCL = false` or a non-consortia tenant — verify ECS BFF mode is NOT activated
- [x] Confirm no regression in non-ECS namespace creation flows

## Related
Fixes [CIRC-2603](https://folio-org.atlassian.net/browse/CIRC-2603)