### PR TITLE
RANCHER-2974. Add ephemeral volume support for Java Karate agent workspace

### DIFF
--- a/src/org/folio/jenkins/PodTemplates.groovy
+++ b/src/org/folio/jenkins/PodTemplates.groovy
@@ -337,6 +337,9 @@ spec:
   void javaKarateAgent(String javaVersion, Closure body) {
     createTemplate(new PodTemplateConfig(
       label: JenkinsAgentLabel.JAVA_KARATE_AGENT.getLabel(),
+      workspaceVolume: steps.genericEphemeralVolume(accessModes: 'ReadWriteOnce',
+        requestsSize: '20Gi',
+        storageClassName: 'gp3'),
       volumes: [steps.persistentVolumeClaim(claimName: MAVEN_CACHE_PVC, mountPath: "${WORKING_DIR}/.m2/repository")],
       containers: [
         buildJavaContainer(javaVersion, [], '5120Mi', '12228Mi')


### PR DESCRIPTION
## Summary

Gives the `javaKarateAgent` pod template a dedicated 20 GiB `genericEphemeralVolume` (`gp3`) instead of inheriting the framework default of 5 GiB. Matches `cypressAgent`'s `requestsSize` exactly (`PodTemplates.groovy:390-392`).

## Problem

The nightly karate-eureka pipeline (`folioScheduledTesting/runNightlyKarateEurekaTests`) has shown three recent failure patterns that all trace to the karate-agent workspace filling up during the post-test stages:

- **#794** (2026-05-05): `Failed to extract cucumber-reports.tar.gz` during `unstash` — `hudson.FilePath.readFromTar` wrapping the underlying `No space left on device`.
- **#795** (2026-05-06): `No space left on device` thrown directly by the `zip cucumber.zip` step in `[Archive] Archive artifacts`.
- **#798** (2026-05-11): Maven completed `BUILD SUCCESS` cleanly, then 6 minutes later the agent went offline because the durable-task heartbeat file (`folio-integration-tests@tmp/durable-df84d0ac`) couldn't be written. Pipeline then hung in a *seems offline / is back online* loop.

Live evidence from the Jenkins Nodes view during the #798 hang:

| Filesystem on `java-karate-agent-d8cjn-zpq5c` | Reported |
|---|---|
| `/home/jenkins/agent` | 18.62 MiB free / 4.84 GiB total |
| `/tmp` (Free Temp Space) | 89.31 GiB |
| Built-In Node (controller) | 269.68 GiB |

The 4.84 GiB total is the binary-units rendering of the framework's 5 GiB default at `src/org/folio/jenkins/PodTemplates.groovy:286-290`. The existing `javaKarateAgent` template (lines 337-349) doesn't set its own `workspaceVolume`, so it inherits that 5 GiB default. A 4-hour Karate run across 60+ modules of test data simply doesn't fit there.

## Change

Adds the following to the `PodTemplateConfig` literal inside `javaKarateAgent`:

```groovy
workspaceVolume: steps.genericEphemeralVolume(accessModes: 'ReadWriteOnce',
  requestsSize: '20Gi',
  storageClassName: 'gp3'),
```

20 GiB is 4× the current default and identical to `cypressAgent`'s baseline — a deliberately conservative first step. The 89 GiB of free Temp Space observed on the agent during #798 confirms the node has ample ephemeral capacity to satisfy the bump. If 20 GiB still proves tight in practice we can revisit upward.

## Phased rollout

This PR is **step 1** of the work tracked under [RANCHER-2974](https://folio-org.atlassian.net/browse/RANCHER-2974). It ships the targeted infrastructure fix in isolation so we can observe at least one healthy nightly run before deciding on the remaining items:

- defensive try/catch in `karateTestUtils.groovy` around `copyCucumberReports` and the three `issueTransition` calls in `syncJiraIssues`
- shorter Maven timeout (or a post-Maven timeout block) to bound any future agent-stall scenarios
- Slack *failed on stage* attribution fix (currently always reports `[Slack] Send notification` as the failing stage)
- long-term removal of the controller↔agent stash/unstash bounce in `attachCucumberReports`

Those will follow in separate PRs after the workspace bump is verified.

## Risk

Low. `genericEphemeralVolume` is a per-pod PVC bound to the pod lifecycle — no shared state, automatically reclaimed when the pod terminates. Pattern is already used and proven for `cypressAgent`. Underlying node ephemeral capacity is sufficient (~89 GiB free seen during #798).
