### PR TITLE
Increase Kafka controller memory request to 4Gi

### DIFF
--- a/terraform/rancher/project/kafka.tf
+++ b/terraform/rancher/project/kafka.tf
@@ -49,7 +49,7 @@ controller:
   heapOpts: "-XX:MaxRAMPercentage=75.0"
   resources:
     requests:
-      memory: 2Gi
+      memory: 4Gi
     limits:
       memory: '${var.kafka_max_mem_size}Mi'
   persistence:


### PR DESCRIPTION
Bump the Kafka controller memory request from 2Gi to 4Gi in terraform/rancher/project/kafka.tf to provide more headroom. Memory limits remain tied to '${var.kafka_max_mem_size}Mi'.