### PR TITLE
RANCHER-2974. Improve nightly Karate Eureka pipeline post-test stability p2

### DIFF
--- a/vars/folioKarateFlow.groovy
+++ b/vars/folioKarateFlow.groovy
@@ -13,7 +13,8 @@ import java.time.Instant
 KarateRunExecutionSummary call(KarateTestsParameters args) {
   Logger logger = new Logger(this, 'Karate flow')
   PodTemplates podTemplates = new PodTemplates(this, true)
-  KarateRunExecutionSummary karateTestsExecutionSummary
+  KarateRunExecutionSummary karateTestsExecutionSummary = new KarateRunExecutionSummary()
+  String failedStage = null
 
   podTemplates.javaKarateAgent(args.javaVersion) {
     dir('folio-integration-tests') {
@@ -86,79 +87,106 @@ KarateRunExecutionSummary call(KarateTestsParameters args) {
                         }
           }
         }
+        if (currentBuild.currentResult == 'FAILURE' && !failedStage) failedStage = STAGE_NAME
 
         stage('[Report] Publish results') {
-          cucumber(
-            buildStatus: 'UNSTABLE',
-            fileIncludePattern: '**/target/karate-reports*/*.json',
-            sortingMethod: 'ALPHABETICAL')
+          catchError(stageResult: 'FAILURE') {
+            cucumber(
+              buildStatus: 'UNSTABLE',
+              fileIncludePattern: '**/target/karate-reports*/*.json',
+              sortingMethod: 'ALPHABETICAL')
 
-          junit(
-            testResults: '**/target/karate-reports*/*.xml',
-            allowEmptyResults: true,
-            skipPublishingChecks: true,)
+            junit(
+              testResults: '**/target/karate-reports*/*.xml',
+              allowEmptyResults: true,
+              skipPublishingChecks: true,)
+          }
+          if (currentBuild.currentResult == 'FAILURE' && !failedStage) failedStage = STAGE_NAME
         }
 
         if (args.reportPortalProjectName && args.reportPortalProjectId) {
           stage('[ReportPortal] Finish run') {
-            stopReportPortalRun(args.reportPortalProjectName, args.reportPortalProjectId)
+            catchError(stageResult: 'FAILURE') {
+              stopReportPortalRun(args.reportPortalProjectName, args.reportPortalProjectId)
+            }
+            if (currentBuild.currentResult == 'FAILURE' && !failedStage) failedStage = STAGE_NAME
           }
         }
 
         stage('[Report] Analyze results') {
-          karateTestsExecutionSummary = karateTestUtils.collectTestsResults('**/target/karate-reports*/karate-summary-json.txt')
-          karateTestUtils.attachCucumberReports(karateTestsExecutionSummary)
+          catchError(stageResult: 'FAILURE') {
+            karateTestsExecutionSummary = karateTestUtils.collectTestsResults('**/target/karate-reports*/karate-summary-json.txt')
+            karateTestUtils.attachCucumberReports(karateTestsExecutionSummary)
+          }
+          if (currentBuild.currentResult == 'FAILURE' && !failedStage) failedStage = STAGE_NAME
         }
 
         stage('[Archive] Archive artifacts') {
-          zip zipFile: 'cucumber.zip', glob: '**/target/karate-reports*/*.json'
-          zip zipFile: 'junit.zip', glob: '**/target/karate-reports*/*.xml'
-          zip zipFile: 'karate-summary.zip', glob: '**/target/karate-reports*/karate-summary-json.txt'
+          catchError(stageResult: 'FAILURE') {
+            zip zipFile: 'cucumber.zip', glob: '**/target/karate-reports*/*.json'
+            zip zipFile: 'junit.zip', glob: '**/target/karate-reports*/*.xml'
+            zip zipFile: 'karate-summary.zip', glob: '**/target/karate-reports*/karate-summary-json.txt'
 
-          archiveArtifacts allowEmptyArchive: true, artifacts: 'cucumber.zip', fingerprint: true, defaultExcludes: false
-          archiveArtifacts allowEmptyArchive: true, artifacts: 'junit.zip', fingerprint: true, defaultExcludes: false
-          archiveArtifacts allowEmptyArchive: true, artifacts: 'karate-summary.zip', fingerprint: true, defaultExcludes: false
-          archiveArtifacts allowEmptyArchive: true, artifacts: 'teams-assignment.json', fingerprint: true, defaultExcludes: false
+            archiveArtifacts allowEmptyArchive: true, artifacts: 'cucumber.zip', fingerprint: true, defaultExcludes: false
+            archiveArtifacts allowEmptyArchive: true, artifacts: 'junit.zip', fingerprint: true, defaultExcludes: false
+            archiveArtifacts allowEmptyArchive: true, artifacts: 'karate-summary.zip', fingerprint: true, defaultExcludes: false
+            archiveArtifacts allowEmptyArchive: true, artifacts: 'teams-assignment.json', fingerprint: true, defaultExcludes: false
+          }
+          if (currentBuild.currentResult == 'FAILURE' && !failedStage) failedStage = STAGE_NAME
         }
 
         if (args.syncWithJira) {
           stage('[Jira] Sync issues') {
-            karateTestUtils.syncJiraIssues(karateTestsExecutionSummary, args.teamAssignment)
+            catchError(stageResult: 'FAILURE') {
+              karateTestUtils.syncJiraIssues(karateTestsExecutionSummary, args.teamAssignment)
+            }
+            if (currentBuild.currentResult == 'FAILURE' && !failedStage) failedStage = STAGE_NAME
           }
         }
 
         if (args.sendSlackNotification) {
           stage('[Slack] Send notification') {
-            slackSend(attachments: folioSlackNotificationUtils
-              .renderBuildAndTestResultMessage(
-                TestType.KARATE
-                , karateTestsExecutionSummary
-                , ''
-                , true
-                , "${env.BUILD_URL}cucumber-html-reports/overview-features.html"
-              )
-              , channel: '#rancher_tests_notifications')
+            catchError(stageResult: 'FAILURE') {
+              slackSend(attachments: folioSlackNotificationUtils
+                .renderBuildAndTestResultMessage(
+                  TestType.KARATE
+                  , karateTestsExecutionSummary
+                  , ''
+                  , true
+                  , "${env.BUILD_URL}cucumber-html-reports/overview-features.html"
+                  , failedStage
+                )
+                , channel: '#rancher_tests_notifications')
+            }
+            if (currentBuild.currentResult == 'FAILURE' && !failedStage) failedStage = STAGE_NAME
           }
         }
 
         if (args.sendTeamsSlackNotification) {
           stage('Send slack notifications to teams') {
-            folioSlackNotificationUtils.renderTeamsTestResultMessages(
-              TestType.KARATE
-              , karateTestsExecutionSummary
-              , args.teamAssignment
-              , ''
-              , true
-              , "${env.BUILD_URL}cucumber-html-reports/overview-features.html")
-              .each {
-                slackSend(attachments: it.value, channel: it.key.getSlackChannel())
-              }
+            catchError(stageResult: 'FAILURE') {
+              folioSlackNotificationUtils.renderTeamsTestResultMessages(
+                TestType.KARATE
+                , karateTestsExecutionSummary
+                , args.teamAssignment
+                , ''
+                , true
+                , "${env.BUILD_URL}cucumber-html-reports/overview-features.html"
+                , failedStage)
+                .each {
+                  slackSend(attachments: it.value, channel: it.key.getSlackChannel())
+                }
+            }
+            if (currentBuild.currentResult == 'FAILURE' && !failedStage) failedStage = STAGE_NAME
           }
         }
 
         if (args.cleanupTenants) {
           stage('Cleanup test tenants') {
-            folioTools.karateTenantsCleanUpUnified(args.okapiUrl, args.keycloakUrl, args.clientId, args.clientSecret)
+            catchError(stageResult: 'FAILURE') {
+              folioTools.karateTenantsCleanUpUnified(args.okapiUrl, args.keycloakUrl, args.clientId, args.clientSecret)
+            }
+            if (currentBuild.currentResult == 'FAILURE' && !failedStage) failedStage = STAGE_NAME
           }
         }
       }

--- a/vars/folioSlackNotificationUtils.groovy
+++ b/vars/folioSlackNotificationUtils.groovy
@@ -8,18 +8,18 @@ import org.folio.testing.*
 import org.folio.testing.teams.Team
 import org.folio.testing.teams.TeamAssignment
 
-String renderBuildResultSection() {
+String renderBuildResultSection(String failedStage = null) {
   SlackBuildResultRenderer slackBuildResult =
     SlackBuildResultRenderer.fromResult(currentBuild.result == null ? "SUCCESS" : currentBuild.result)
 
-  return renderBuildResultSection(slackBuildResult)
+  return renderBuildResultSection(slackBuildResult, failedStage)
 }
 
-String renderBuildResultSection(SlackBuildResultRenderer buildResult) {
+String renderBuildResultSection(SlackBuildResultRenderer buildResult, String failedStage = null) {
   return buildResult.renderSection(
     env.JOB_BASE_NAME
     , env.BUILD_NUMBER
-    , STAGE_NAME
+    , failedStage ?: STAGE_NAME
     , "${env.BUILD_URL}console"
   )
 }
@@ -59,10 +59,11 @@ String renderTestResultSection(TestType type, IExecutionSummary summary
 }
 
 String renderBuildAndTestResultMessage(TestType type, IExecutionSummary summary
-                                       , String buildName, boolean useReportPortal, String url) {
+                                       , String buildName, boolean useReportPortal, String url
+                                       , String failedStage = null) {
   return SlackHelper.renderMessage(
     [
-      renderBuildResultSection()
+      renderBuildResultSection(failedStage)
       , renderTestResultSection(type, summary, buildName, useReportPortal, url)
     ]
   )
@@ -71,7 +72,8 @@ String renderBuildAndTestResultMessage(TestType type, IExecutionSummary summary
 Map<Team, String> renderTeamsTestResultMessages(TestType type
                                                 , IRunExecutionSummary summary
                                                 , TeamAssignment teamAssignment
-                                                , String buildName, boolean useReportPortal, String url) {
+                                                , String buildName, boolean useReportPortal, String url
+                                                , String failedStage = null) {
 
   Map<Team, List<IModuleExecutionSummary>> teamsResults = summary.getModuleResultByTeam(teamAssignment)
   Map<Team, String> teamsRenderSection = [:]
@@ -79,7 +81,7 @@ Map<Team, String> renderTeamsTestResultMessages(TestType type
   teamsResults.each { teamResults ->
     teamsRenderSection[teamResults.key] = SlackHelper.renderMessage(
       [
-        renderBuildResultSection()
+        renderBuildResultSection(failedStage)
         , renderTestResultSection(type, summary, buildName, useReportPortal, url)
         , renderTeamTestResultSection(type, teamResults.key, teamResults.value)
       ]

--- a/vars/karateTestUtils.groovy
+++ b/vars/karateTestUtils.groovy
@@ -50,7 +50,12 @@ KarateRunExecutionSummary collectTestsResults(String karateSummaryFolder) {
  * @param summary karate tests execution statistics
  */
 void attachCucumberReports(KarateRunExecutionSummary summary) {
-  copyCucumberReports()
+  try {
+    copyCucumberReports()
+  } catch (Exception e) {
+    echo "Skipping cucumber report attachment: ${e.message}"
+    return
+  }
 
   List<KarateFeatureExecutionSummary> features = summary.modulesExecutionSummary.collect { name, moduleSummary ->
     moduleSummary.features
@@ -135,21 +140,21 @@ void syncJiraIssues(KarateRunExecutionSummary karateTestsExecutionSummary, TeamA
           e.printStackTrace()
         }
 
-        // Issue fixed and no any activity have been started on the issue
-        if (issue.status == KarateConstants.ISSUE_OPEN_STATUS && !featureSummary.failed) {
-          jiraClient.issueTransition(issue.id, KarateConstants.ISSUE_CLOSED_STATUS)
-          echo "Jira ticket '${issue.getKey()}' status changed to 'Closed'"
-          // Issue is in "In Review" status
-        } else if (issue.status == KarateConstants.ISSUE_IN_REVIEW_STATUS) {
-          // Feature us still failing
-          if (featureSummary.failed) {
-            jiraClient.issueTransition(issue.id, KarateConstants.ISSUE_OPEN_STATUS)
-            echo "Jira ticket '${issue.getKey()}' status changed to 'Open'"
-            // Feature has been fixed
-          } else {
+        try {
+          if (issue.status == KarateConstants.ISSUE_OPEN_STATUS && !featureSummary.failed) {
             jiraClient.issueTransition(issue.id, KarateConstants.ISSUE_CLOSED_STATUS)
             echo "Jira ticket '${issue.getKey()}' status changed to 'Closed'"
+          } else if (issue.status == KarateConstants.ISSUE_IN_REVIEW_STATUS) {
+            if (featureSummary.failed) {
+              jiraClient.issueTransition(issue.id, KarateConstants.ISSUE_OPEN_STATUS)
+              echo "Jira ticket '${issue.getKey()}' status changed to 'Open'"
+            } else {
+              jiraClient.issueTransition(issue.id, KarateConstants.ISSUE_CLOSED_STATUS)
+              echo "Jira ticket '${issue.getKey()}' status changed to 'Closed'"
+            }
           }
+        } catch (Exception e) {
+          echo "Error transitioning jira ticket '${issue.getKey()}': ${e.message}"
         }
       }
     }


### PR DESCRIPTION
## Summary

Step 2 of [RANCHER-2974](https://folio-org.atlassian.net/browse/RANCHER-2974). Hardens the post-test tail of the nightly Karate Eureka pipeline so a single late-stage failure can't take down Slack notifications, Jira ticket updates, or test-tenant cleanup. Also fixes the long-standing Slack *"failed on stage"* misattribution where every FAILURE-status message claimed the failure happened in `[Slack] Send notification`.

Builds on #1302 (workspace volume bump) which addressed the disk-pressure failures directly; this PR addresses the cascading-failure pattern that disk pressure exposed.

## Problem

Recent nightly runs surfaced four distinct failure modes in the post-test stages of `folioScheduledTesting/runNightlyKarateEurekaTests`:

- **#793** — A Jira ticket whose workflow no longer offered a `Closed` transition caused `jiraClient.issueTransition(...)` in `syncJiraIssues` to throw `AbortException`. The exception was unprotected and aborted the entire pipeline tail mid-iteration: Slack notifications, per-team channels, and tenant cleanup were all skipped over a single misconfigured ticket.
- **#794 / #795 / #798** — Agent workspace disk pressure caused `unstash` / `zip` operations in the post-test stages to throw `IOException: No space left on device`. #1302 addresses the disk pressure itself, but the structural weakness — any single late-stage failure cascading and skipping downstream stages — remained.
- **#797** — A real Maven test failure correctly marked the build as `FAILURE` via the existing `catchError` wrapper. Slack notifications fired, but every message said *"Pipilene failed on stage - [Slack] Send notification"* because `vars/folioSlackNotificationUtils.groovy:22` passed `env.STAGE_NAME` (the *currently executing* stage) into the `FAILED_TEXT` template instead of the *actually failing* stage.
- **Cascade NPE** — If `[Report] Analyze results` throws (e.g. a malformed `karate-summary-json.txt`), the pipeline-scoped `karateTestsExecutionSummary` stays `null`. Downstream `syncJiraIssues(null, ...)` and `renderBuildAndTestResultMessage(TYPE, null, ...)` would NPE on first field access; both Slack and Jira would silently produce nothing.

## Change

### `vars/folioKarateFlow.groovy`

- Declares a pipeline-scoped `String failedStage = null` and initializes `karateTestsExecutionSummary` to `new KarateRunExecutionSummary()` instead of leaving it `null`. The empty summary lets downstream stages (`syncJiraIssues`, the two Slack renderers) degrade gracefully when `[Report] Analyze results` fails — Slack still sends a *"0 tests"* message, Jira sync no-ops, tenant cleanup still runs.
- Wraps each post-Maven stage body (`[Report] Publish results`, `[ReportPortal] Finish run`, `[Report] Analyze results`, `[Archive] Archive artifacts`, `[Jira] Sync issues`, `[Slack] Send notification`, `Send slack notifications to teams`, `Cleanup test tenants`) in `catchError(stageResult: 'FAILURE')` so a single stage failure marks itself `FAILURE` but doesn't abort the chain.
- After each post-Maven stage body, snapshots `failedStage = STAGE_NAME` when `currentBuild.currentResult == 'FAILURE'` and `failedStage` isn't already set. The `!failedStage` guard ensures the **first** failing stage owns the attribution.
- Passes `failedStage` into both `slackSend` renderer calls so the Slack message text reflects the actual failing stage.

### `vars/folioSlackNotificationUtils.groovy`

- Adds an optional trailing `String failedStage = null` parameter to `renderBuildResultSection`, `renderBuildAndTestResultMessage`, `renderTeamsTestResultMessages`.
- When non-`null`, the value is threaded into the existing `BUILD_TXT_STAGE_NAME` placeholder. When `null`, the existing fallback to the `STAGE_NAME` env var preserves back-compat for other callers (e.g. `renderFailedBuildResultMessage` used in the outer Jenkinsfile for provision-failure notifications, which is rendered from inside the actually-failing stage and so still produces correct attribution).
- The template at `SlackBuildResultTemplates.groovy:8` is unchanged — only the data feeding the placeholder was wrong.

### `vars/karateTestUtils.groovy`

- `attachCucumberReports` wraps its `copyCucumberReports()` call in try/catch. If the controller-side `cp` / `stash` / agent-side `unstash` round-trip fails (the #794 pattern), the function logs and returns early instead of throwing. Result: missing per-feature cucumber URLs in Slack/Jira messages, not a dead pipeline.
- `syncJiraIssues` wraps the entire transition if/else chain in a single try/catch. If `jiraClient.issueTransition(...)` throws for one ticket (the #793 workflow-gap pattern), the failure is logged and the loop continues to the next ticket. The outer `catchError` in `folioKarateFlow.groovy` still protects against catastrophic `syncJiraIssues` failures (auth, network) — the two layers handle different failure scopes (per-iteration vs. stage-level).

## Behavior matrix

| Scenario | Before this PR | After this PR |
|---|---|---|
| One Jira ticket has no `Closed` transition | Pipeline aborts; Slack / cleanup skipped (#793 pattern) | Ticket logged and skipped; loop continues; pipeline finishes cleanly |
| `unstash` / `zip` throws mid-stage | Pipeline aborts; downstream stages skipped | Stage marked `FAILURE`; downstream stages run |
| Maven test failure (`mod-scheduler`-style) | Slack: *"failed on stage [Slack] Send notification"* | Slack: *"failed on stage [Maven] Execute karate tests"* |
| `collectTestsResults` throws / Analyze fails | NPE cascade through Slack and Jira; both silently skipped | Empty summary; Slack sends *"0 tests"* message; Jira no-ops cleanly; cleanup runs |

## Risk

Low. All changes are additive — no existing call signatures changed, no removed behavior:

- New `failedStage` parameter is opt-in (defaults to `null`; falls back to existing `STAGE_NAME` env var).
- New try/catch and `catchError` blocks only change which errors propagate vs. log.
- Empty `KarateRunExecutionSummary()` initialization is safe — the class has an implicit no-arg constructor with `modulesExecutionSummary = [:]`; all getter methods and `getModuleResultByTeam` handle the empty case.
- Per-stage `catchError(stageResult: 'FAILURE')` preserves `FAILURE` attribution in the Jenkins build view so failures remain visible.
