### PR TITLE
RANCHER-2974-p3. Handle `NaN` in Karate JSON files by replacing with `0`

### DIFF
--- a/vars/karateTestUtils.groovy
+++ b/vars/karateTestUtils.groovy
@@ -25,7 +25,7 @@ KarateRunExecutionSummary collectTestsResults(String karateSummaryFolder) {
     String[] split = path.split("/")
     String moduleName = split[split.size() - 4]
 
-    def contents = readJSON file: path
+    def contents = readJSON text: readFile(file: path).replaceAll(/\bNaN\b/, '0')
 
     // find corresponding cucumber reports to get feature display name
     Map<String, String> displayNames = [:]


### PR DESCRIPTION
## Summary

Step 3 of [RANCHER-2974](https://folio-org.atlassian.net/browse/RANCHER-2974). One-line sanitization in `karateTestUtils.collectTestsResults` that strips invalid `NaN` tokens from Karate's `karate-summary-json.txt` before passing the content to Jenkins' `readJSON`. Prevents intermittent false-positive `FAILURE` builds when Karate's parallel scheduler produces an empty runner slot.

Builds on #1302 (workspace volume) and #1314 (post-test stage hardening + Slack attribution).

## Problem

Build #813 reached `[Report] Analyze results` with everything else healthy (Maven `BUILD SUCCESS`, no disk pressure, all post-test stages reachable) and then threw:

```
net.sf.json.JSONException: Unquotted string 'NaN'
  at PluginClassLoader for pipeline-utility-steps//...ReadJSONStepExecution.doRun
```

The throw happened during the `readJSON` call on `karate-summary-json.txt` inside `karateTestUtils.collectTestsResults`. Extracting the artifact archive and inspecting the file directly:

```json
{"efficiency":NaN,"totalTime":0.0,"threads":1,"resultDate":"2026-05-27 08:40:44 PM",
 "env":"folio-testing-karate","version":"1.5.1","scenariosfailed":0,
 "featureSummary":[],"featuresPassed":0,"featuresFailed":0,"featuresSkipped":1,
 "scenariosPassed":0,"elapsedTime":0.0}
```

A grep across all 812 per-scenario `*.json` files from the same build returned **zero** `NaN` tokens, confirming the issue is in the Karate **summary** writer, not the per-scenario reports.

Root cause: Karate's parallel scheduler assigned **zero scenarios** to this runner thread (`scenariosPassed: 0`, `scenariosfailed: 0`, `featureSummary: []`). The summary writer computes `efficiency = scenariosPassed * 100 / (scenariosPassed + scenariosfailed)` → `0/0` → JVM `Double.NaN`, which the writer serializes as the literal token `NaN`. This is **not valid JSON per RFC 8259**, and Jenkins' strict `net.sf.json` parser rejects it.

Step 2 (#1314) correctly contained the failure — Archive uploaded, Slack notification fired, Jira sync ran cleanly against the empty fallback summary, tenant cleanup ran. But the build's final status was a misleading `FAILURE` rather than the actual `UNSTABLE` / `SUCCESS` the tests warranted. Without this fix we expect 10-30% of nightlies to surface the same false positive, depending on how often the scheduler produces an empty slot.

## Change

In `vars/karateTestUtils.groovy::collectTestsResults` (line 28):

```diff
-    def contents = readJSON file: path
+    def contents = readJSON text: readFile(file: path).replaceAll(/\bNaN\b/, '0')
```

That's the whole patch — `readFile` + regex strip + `readJSON text:` instead of `readJSON file:`.

### Why `\bNaN\b` and not a plain `.replace('NaN', '0')`

The regex matches only when `NaN` is bracketed by non-word characters (e.g. `:NaN,` or ` NaN ` — exactly how Karate emits the literal token in numeric fields). Hypothetical strings like `"Banana"` are not affected — the substring `aNa` lies between word characters, not boundaries. Karate's summary format also never embeds the literal `NaN` substring inside any string field, but the word-boundary guard is the cheaper defensive choice over hoping that stays true.

### Why `0` is the right replacement

For the `efficiency` field specifically (a pass-rate percentage), `0` is the semantically correct value for an empty runner slot — there were zero scenarios, so an efficiency of `0%` honestly represents what happened. Other fields in the summary (`totalTime`, `elapsedTime`, counts) are already `0.0` or `0` in this case. The empty slot's `featureSummary: []` already correctly says "no features ran here", so the rest of the pipeline sees an empty-but-valid module result and continues.

### Scope

- Only the summary-file `readJSON` (line 28) is touched.
- The per-scenario `readJSON` (line 34) is untouched — those reports have never carried `NaN` (verified across 812 files from #813) and use a different writer.

## Behavior matrix

| Scenario | Before (post-#1314) | After this PR |
|---|---|---|
| All Karate parallel slots received at least one scenario | `[Report] Analyze results` succeeds → `UNSTABLE` / `SUCCESS` | Same |
| Karate scheduler produces an empty slot → summary has `"efficiency":NaN` | `[Report] Analyze results` throws `JSONException`; build marked `FAILURE` even though tests are fine; downstream stages still run thanks to step 2 hardening | `NaN` is normalized to `0`; summary parsed cleanly; `[Report] Analyze results` succeeds; build status reflects real test outcomes |

## Risk

Very low. Strictly additive sanitization on a parse path — no behavior change for any input that doesn't currently fail. The regex only matches `NaN` as a standalone token. Worst-case false positive (replacing a literal three-character `NaN` inside a string field) is defended against by the word-boundary guard and, redundantly, by Karate's own summary schema not putting `NaN` inside strings.
