### PR TITLE
RANCHER-3005. Improve determination logic in the createNamespace pipeline

### DIFF
--- a/pipelines/folioRancher/folioNamespaceTools/manageNamespace/createNamespace/Jenkinsfile
+++ b/pipelines/folioRancher/folioNamespaceTools/manageNamespace/createNamespace/Jenkinsfile
@@ -11,7 +11,7 @@ import org.jenkinsci.plugins.workflow.libs.Library
 import static groovy.json.JsonOutput.prettyPrint
 import static groovy.json.JsonOutput.toJson
 
-@Library('pipelines-shared-library@test-sunflower') _
+@Library('pipelines-shared-library') _
 
 @Field final String createNamespaceJobName = Constants.JENKINS_CREATE_NAMESPACE_FROM_BRANCH_JOB
 @Field final String deleteNamespaceJobName = Constants.JENKINS_DELETE_NAMESPACE_JOB

--- a/pipelines/folioRancher/folioNamespaceTools/manageNamespace/createNamespace/Jenkinsfile
+++ b/pipelines/folioRancher/folioNamespaceTools/manageNamespace/createNamespace/Jenkinsfile
@@ -5,9 +5,13 @@ import groovy.transform.Field
 import org.folio.Constants
 import org.folio.jenkins.PodTemplates
 import org.folio.models.parameters.CreateNamespaceParameters
+import org.folio.utilities.Logger
 import org.jenkinsci.plugins.workflow.libs.Library
 
-@Library('pipelines-shared-library') _
+import static groovy.json.JsonOutput.prettyPrint
+import static groovy.json.JsonOutput.toJson
+
+@Library('pipelines-shared-library@test-sunflower') _
 
 @Field final String createNamespaceJobName = Constants.JENKINS_CREATE_NAMESPACE_FROM_BRANCH_JOB
 @Field final String deleteNamespaceJobName = Constants.JENKINS_DELETE_NAMESPACE_JOB
@@ -98,6 +102,9 @@ ansiColor('xterm') {
     }
 
     stage('Spinning up env') {
+      Logger logger = new Logger(this, 'createNamespace')
+      logger.info("Create namespace parameters:\n${prettyPrint(toJson(namespace))}")
+
       folioTriggerJob.createNamespaceFromBranch(createNamespaceJobName, namespace)
     }
   }

--- a/src/org/folio/models/parameters/CreateNamespaceParameters.groovy
+++ b/src/org/folio/models/parameters/CreateNamespaceParameters.groovy
@@ -2,7 +2,6 @@ package org.folio.models.parameters
 
 import com.cloudbees.groovy.cps.NonCPS
 import org.folio.Constants
-import org.folio.rest_v2.EntitlementApproach
 import org.folio.rest_v2.FolioRelease
 import org.folio.rest_v2.PlatformType
 
@@ -436,9 +435,7 @@ class CreateNamespaceParameters implements Cloneable {
         }
       }
 
-      if (parameters.initParams.entitlementApproach == null && defaults.entitlementApproach != null)
-        parameters.initParams.entitlementApproach = defaults.entitlementApproach as EntitlementApproach
-
+      parameters.initParams.applyDefaults(parameters.releaseType)
       parameters.folioExtensions = (parameters.folioExtensions + DependentParametersResolver.resolveFolioExtensions(parameters)).unique()
 
       return parameters

--- a/src/org/folio/models/parameters/DependentParametersResolver.groovy
+++ b/src/org/folio/models/parameters/DependentParametersResolver.groovy
@@ -1,7 +1,6 @@
 package org.folio.models.parameters
 
 import org.folio.Constants
-import org.folio.rest_v2.EntitlementApproach
 import org.folio.rest_v2.FolioRelease
 import org.folio.rest_v2.PlatformType
 
@@ -24,8 +23,6 @@ class DependentParametersResolver {
     }
 
     // Release-driven
-    result.entitlementApproach = (releaseType == FolioRelease.SUNFLOWER) ? EntitlementApproach.CREATE : EntitlementApproach.STATE
-    result.setBaseUrl = (releaseType != FolioRelease.SUNFLOWER)
     result.configExtensions = (releaseType == FolioRelease.SUNFLOWER) ? ['sunflower'] : []
 
     // Cluster-driven

--- a/src/org/folio/models/parameters/InitializeFromScratchParameters.groovy
+++ b/src/org/folio/models/parameters/InitializeFromScratchParameters.groovy
@@ -1,8 +1,11 @@
 package org.folio.models.parameters
 
 import org.folio.rest_v2.EntitlementApproach
+import org.folio.rest_v2.FolioRelease
 
 class InitializeFromScratchParameters {
+
+  Set<String> modifiedFields = [] as Set
 
   EntitlementApproach entitlementApproach
   boolean setBaseUrl = true
@@ -10,16 +13,31 @@ class InitializeFromScratchParameters {
 
   InitializeFromScratchParameters withEntitlementApproach(EntitlementApproach entitlementApproach) {
     this.entitlementApproach = entitlementApproach
+    this.modifiedFields << 'entitlementApproach'
     return this
   }
 
   InitializeFromScratchParameters withSetBaseUrl(boolean setBaseUrl) {
     this.setBaseUrl = setBaseUrl
+    this.modifiedFields << 'setBaseUrl'
     return this
   }
 
   InitializeFromScratchParameters withMigrate(boolean migrate) {
     this.migrate = migrate
+    this.modifiedFields << 'migrate'
+    return this
+  }
+
+  InitializeFromScratchParameters applyDefaults(FolioRelease releaseType) {
+    if (releaseType == null) return this
+
+    if (!modifiedFields.contains('entitlementApproach'))
+      this.entitlementApproach = (releaseType == FolioRelease.SUNFLOWER) ? EntitlementApproach.CREATE : EntitlementApproach.STATE
+
+    if (!modifiedFields.contains('setBaseUrl'))
+      this.setBaseUrl = (releaseType != FolioRelease.SUNFLOWER)
+
     return this
   }
 }


### PR DESCRIPTION
## Summary

Fixes [RANCHER-3005](https://folio-org.atlassian.net/browse/RANCHER-3005). For Sunflower (`R1-2025`) platform branches, `initParams.setBaseUrl` was emitted as `true` even though [RANCHER-2936](https://folio-org.atlassian.net/browse/RANCHER-2936) introduced release-aware defaults that should set it to `false`. As a result, downstream `createNamespaceFromBranch` invoked `Configurations.setBaseUrl(tenant)` against the Sunflower tenant — exactly the behavior RANCHER-2936 was meant to prevent.

The fix encapsulates the release-aware initParams policy inside `InitializeFromScratchParameters` itself (where the fields live), drops the leaky flat-map plumbing from `DependentParametersResolver`, and collapses the Builder's special-case block into a single `applyDefaults(...)` call.

## Problem

Build `folioRancher/manageNamespace/createNamespace #232` on a Sunflower branch logged:

```json
"initParams": {
    "migrate": false,
    "setBaseUrl": true,
    "entitlementApproach": "CREATE"
}
```

`releaseType` was correctly classified as `SUNFLOWER` (`configExtensions: ["sunflower"]`, `entitlementApproach: "CREATE"`), but `setBaseUrl` ignored the resolver's `releaseType != SUNFLOWER` rule.

**Root cause.** `DependentParametersResolver.resolve()` returned a flat `Map<String, Object>` with keys including `entitlementApproach` and `setBaseUrl`. But those fields don't live on `CreateNamespaceParameters` directly — they live on the nested `parameters.initParams` (`InitializeFromScratchParameters`). The Builder's defaults loop gated on `parameters.hasProperty(name)`, which is `false` for `setBaseUrl` (it's on `initParams`, not on `parameters` itself), so the resolver's value was silently dropped. A separate special-case if-block lifted `entitlementApproach` into `initParams` using an enum null-sentinel; `setBaseUrl` is a primitive `boolean` with a hardcoded default `= true`, has no null sentinel, and had no equivalent block — so it always won at `true`.

## Change

Three files, encapsulation-first.

**`InitializeFromScratchParameters`** owns its own policy:

- Adds `Set<String> modifiedFields`; `withEntitlementApproach` / `withSetBaseUrl` / `withMigrate` now record the field they touched.
- Adds `applyDefaults(FolioRelease releaseType)`, which applies release-aware defaults only to fields the caller did **not** explicitly set:

```groovy
InitializeFromScratchParameters applyDefaults(FolioRelease releaseType) {
  if (releaseType == null) return this
  if (!modifiedFields.contains('entitlementApproach'))
    this.entitlementApproach = (releaseType == FolioRelease.SUNFLOWER) ? EntitlementApproach.CREATE : EntitlementApproach.STATE
  if (!modifiedFields.contains('setBaseUrl'))
    this.setBaseUrl = (releaseType != FolioRelease.SUNFLOWER)
  return this
}
```

**`DependentParametersResolver`** stops leaking initParams fields:

- Removes `result.entitlementApproach = ...` and `result.setBaseUrl = ...`. The resolver no longer knows the release-aware initParams policy — that's now `InitializeFromScratchParameters`'s job. The resolver still emits `releaseType`, which is what `applyDefaults` consumes.

**`CreateNamespaceParameters.Builder.build()`** loses the special case:

```diff
- if (parameters.initParams.entitlementApproach == null && defaults.entitlementApproach != null)
-   parameters.initParams.entitlementApproach = defaults.entitlementApproach as EntitlementApproach
+ parameters.initParams.applyDefaults(parameters.releaseType)
  parameters.folioExtensions = (parameters.folioExtensions + DependentParametersResolver.resolveFolioExtensions(parameters)).unique()
```

The two postprocessing lines are now symmetric: both delegate to the type that owns the data (`InitializeFromScratchParameters` for initParams, the resolver helper for `folioExtensions`).

**`createNamespace/Jenkinsfile`** also gains the `prettyPrint(toJson(namespace))` logging line that surfaced the bug, preserved so future regressions of the same shape stay visible.

## Behavior matrix

| Scenario | Before | After |
|---|---|---|
| `createNamespace` on Sunflower branch (e.g. `R1-2025-ci`) | `setBaseUrl=true` → downstream `PUT /base-url` runs against Sunflower tenant (wrong) | `setBaseUrl=false` → `PUT /base-url` skipped |
| `createNamespace` on non-Sunflower branch (`R1-2026`, `snapshot`) | `setBaseUrl=true` | `setBaseUrl=true` (unchanged) |
| `createNamespaceFromBranch` with explicit `SET_BASE_URL` from UI | User value wins | User value still wins (`modifiedFields` blocks the release default) |
| `createNamespaceFromBranch` with explicit `ENTITLEMENT_APPROACH` only (partial init) | `entitlementApproach` kept, but `setBaseUrl` reverts to hardcoded `true` | `entitlementApproach` kept, `setBaseUrl` filled release-aware |

## Risk

Low. The public Builder API is unchanged. `InitializeFromScratchParameters` keeps its existing field defaults (`setBaseUrl = true`, `migrate = false`) as a fallback for any caller that instantiates the class directly without going through the Builder/resolver path. The two consumers of the Builder in this repo:

- `pipelines/.../createNamespace/Jenkinsfile` — never calls `.initParams(...)`, gets the release-aware defaults. Sunflower behavior is now correct, non-Sunflower unchanged.
- `pipelines/.../createNamespaceFromBranch/Jenkinsfile` — calls `.initParams(new InitializeFromScratchParameters().withEntitlementApproach(...).withSetBaseUrl(params.SET_BASE_URL))`. Both fields land in `modifiedFields`, so the release default is fully bypassed — unchanged behavior.
