### PR TITLE
RANCHER-2841 automate To Investigate test re-verification

### DIFF
--- a/pipelines/folioRancher/folioScheduledTesting/folioQualityGates/Jenkinsfile
+++ b/pipelines/folioRancher/folioScheduledTesting/folioQualityGates/Jenkinsfile
@@ -118,7 +118,7 @@ ansiColor('xterm') {
         cypressParameters.setNumberOfWorkers(5)
         cypressParameters.setTimeout('180')
 
-        cypressTestsExecutionSummary = folioCypressFlow.call(cypressParameters.getCiBuildId(), [cypressParameters], false, true, 'ci')
+        cypressTestsExecutionSummary = folioCypressFlow.call(cypressParameters.getCiBuildId(), [cypressParameters], false, true, 'ci', false)
       }
       if (params.INCLUDE_KARATE) {
         branches['Karate'] = { ->

--- a/pipelines/folioRancher/folioScheduledTesting/runNightlyCypressEurekaTests/Jenkinsfile
+++ b/pipelines/folioRancher/folioScheduledTesting/runNightlyCypressEurekaTests/Jenkinsfile
@@ -104,6 +104,6 @@ ansiColor('xterm') {
         throw new Exception("Provision of the environment is failed: " + new_ex)
       }
     }
-    folioCypressFlow.call(cypressParameters.getCiBuildId(), [cypressParameters], false, reportPortalUse, reportPortalRunType)
+    folioCypressFlow.call(cypressParameters.getCiBuildId(), [cypressParameters], true, reportPortalUse, reportPortalRunType, true)
   }
 }

--- a/pipelines/folioRancher/folioScheduledTesting/runNightlyCypressTests/Jenkinsfile
+++ b/pipelines/folioRancher/folioScheduledTesting/runNightlyCypressTests/Jenkinsfile
@@ -125,5 +125,5 @@ ansiColor('xterm') {
     }
   }
 
-  folioCypressFlow.call(cypressParameters.getCiBuildId(), [cypressParameters], false, reportPortalUse, reportPortalRunType)
+  folioCypressFlow.call(cypressParameters.getCiBuildId(), [cypressParameters], false, reportPortalUse, reportPortalRunType, false)
 }

--- a/src/org/folio/jenkins/PodTemplates.groovy
+++ b/src/org/folio/jenkins/PodTemplates.groovy
@@ -395,7 +395,7 @@ spec:
         storageClassName: 'gp3'),
       volumes: [steps.persistentVolumeClaim(claimName: YARN_CACHE_PVC, mountPath: "${WORKING_DIR}/.yarn/cache")],
       containers: [
-        buildCypressContainer([], '2048Mi', '4096Mi'),
+        buildCypressContainer([], '4096Mi', '4096Mi'),
       ]
     )) {
       steps.node(JenkinsAgentLabel.CYPRESS_AGENT.getLabel()) {

--- a/vars/folioCypress.groovy
+++ b/vars/folioCypress.groovy
@@ -1,6 +1,7 @@
 import groovy.json.JsonException
 import org.folio.Constants
 import org.folio.client.reportportal.ReportPortalClient
+import org.folio.client.reportportal.ReportPortalConstants
 import org.folio.models.parameters.CypressTestsParameters
 import org.folio.testing.TestType
 import org.folio.testing.cypress.results.CypressRunExecutionSummary
@@ -241,11 +242,17 @@ String archiveTestResults(String workerId) {
     String stashName = "allure-results-${workerId}"
     String tarName = "allure-results-${workerId}.tar.gz"
 
-    sh """
-      tar -zcf ${tarName} allure-results/*
-      md5sum ${tarName} > ${tarName}.md5
-      test -f ${tarName}
-    """
+    try {
+      sh """
+        tar -zcf ${tarName} allure-results/*
+        md5sum ${tarName} > ${tarName}.md5
+        test -f ${tarName}
+      """
+    } catch (Exception e) {
+      echo("Archiving test results was interrupted: ${e.getMessage()}")
+      currentBuild.result = 'UNSTABLE'
+      return null
+    }
 
     archiveArtifacts artifacts: "${tarName}, ${tarName}.md5", allowEmptyArchive: true, fingerprint: true, defaultExcludes: false
     stash name: stashName, includes: "${tarName}, ${tarName}.md5"
@@ -337,6 +344,31 @@ void finalizeReportPortal(ReportPortalClient reportPortalClient) {
       echo("Couldn't stop run in ReportPortal\nError: ${e.getMessage()}")
     }
   }
+}
+
+int runFailedTestsRecheck(String launchName) {
+  validateParameter(launchName, 'launchName')
+
+  int flakyCount = 0
+  stage('[Cypress & ReportPortal] Re-check "To Investigate" tests') {
+    try {
+      withCredentials([string(credentialsId: ReportPortalConstants.CREDENTIALS_ID, variable: 'CI_API_KEY')]) {
+        String countFile = 'flaky-recheck-count.txt'
+
+        timeout(time: 5, unit: 'HOURS') {
+          sh "node scripts/report-portal/runFailedTests.js --launchName ${launchName}"
+        }
+
+        if (fileExists(countFile)) {
+          flakyCount = readFile(countFile).trim().toInteger()
+          sh "rm -f ${countFile}"
+        }
+      }
+    } catch (Exception e) {
+      echo("runFailedTests re-check failed: ${e.getMessage()}")
+    }
+  }
+  return flakyCount
 }
 
 /**
@@ -432,7 +464,7 @@ CypressRunExecutionSummary analyzeResults() {
  * @param channel The Slack channel to send notifications to. Defaults to '#rancher_tests_notifications'.
  */
 void sendNotifications(CypressRunExecutionSummary testRunExecutionSummary, String ciBuildId, boolean useReportPortal,
-                       String channel = '#rancher_tests_notifications') {
+                       String channel = '#rancher_tests_notifications', int flakyCount = 0) {
   validateParameter(testRunExecutionSummary, 'Test run execution summary')
   validateParameter(ciBuildId, 'CI build ID')
   validateParameter(useReportPortal, 'Use Report Portal')
@@ -443,7 +475,9 @@ void sendNotifications(CypressRunExecutionSummary testRunExecutionSummary, Strin
         testRunExecutionSummary,
         ciBuildId,
         useReportPortal,
-        "${env.BUILD_URL}allure/"),
+        "${env.BUILD_URL}allure/",
+        null,
+        flakyCount),
       channel: channel)
   }
 }

--- a/vars/folioCypressFlow.groovy
+++ b/vars/folioCypressFlow.groovy
@@ -52,7 +52,8 @@ private static def cypressStash(String key = null) {
  * @throws Exception            Propagates any exceptions encountered during the execution flow.
  */
 CypressRunExecutionSummary call(String ciBuildId, List<CypressTestsParameters> testsToRun, boolean sendNotification = false,
-                                boolean reportPortalUse = false, String reportPortalRunType = '') {
+                                boolean reportPortalUse = false, String reportPortalRunType = '',
+                                boolean recheckFailedTests = false) {
   folioCypress.validateParameter(ciBuildId, 'ciBuildId')
   folioCypress.validateParameter(testsToRun, 'testsToRun')
 
@@ -64,6 +65,9 @@ CypressRunExecutionSummary call(String ciBuildId, List<CypressTestsParameters> t
   String reportPortalExecParameters = ''
 
   List allureResultsList = []
+
+  boolean mainPhaseSucceeded = false
+  int flakyCount = 0
 
   try {
     testsToRun.each { CypressTestsParameters testParams ->
@@ -148,7 +152,10 @@ CypressRunExecutionSummary call(String ciBuildId, List<CypressTestsParameters> t
                   testParams.testrailProjectID,
                   testParams.testrailRunID)
 
-                localAllureResults.add(folioCypress.archiveTestResults(workerId))
+                String stashName = folioCypress.archiveTestResults(workerId)
+                if (stashName) {
+                  localAllureResults.add(stashName)
+                }
               }
             }
           }
@@ -157,9 +164,11 @@ CypressRunExecutionSummary call(String ciBuildId, List<CypressTestsParameters> t
         timeout(time: testParams.timeout, unit: 'MINUTES') {
           parallel(workers)
         }
+
         allureResultsList.addAll(localAllureResults)
       }
     }
+    mainPhaseSucceeded = true
   } catch (Exception e) {
     logger.error("Error during Cypress tests execution: ${e.getMessage()}")
   } finally {
@@ -177,10 +186,30 @@ CypressRunExecutionSummary call(String ciBuildId, List<CypressTestsParameters> t
       }
 
       testRunExecutionSummary = folioCypress.analyzeResults()
+    }
 
+    if (recheckFailedTests && reportPortalUse && reportPortalClient != null && mainPhaseSucceeded
+      && testRunExecutionSummary != null && testRunExecutionSummary.getPassRate() > 80) {
+      podTemplates.cypressAgent {
+        container('cypress') {
+          stage('[Stash] Extract tests') {
+            unstash name: cypressStash('name')
+            sh """
+              md5sum -c ${cypressStash('checksum')}
+              tar -zxf ${cypressStash('archive')}
+              rm -rf ${cypressStash('archive')} ${cypressStash('checksum')}
+            """
+          }
+          flakyCount = folioCypress.runFailedTestsRecheck(ciBuildId)
+        }
+      }
+    }
+
+    podTemplates.rancherJavaAgent {
       try {
         if (sendNotification) {
-          folioCypress.sendNotifications(testRunExecutionSummary, ciBuildId, reportPortalUse)
+          folioCypress.sendNotifications(testRunExecutionSummary, ciBuildId, reportPortalUse,
+            '#rancher_tests_notifications', flakyCount)
         }
       } catch (Exception e) {
         logger.warning("Error sending notifications: ${e.getMessage()}")

--- a/vars/folioSlackNotificationUtils.groovy
+++ b/vars/folioSlackNotificationUtils.groovy
@@ -60,13 +60,15 @@ String renderTestResultSection(TestType type, IExecutionSummary summary
 
 String renderBuildAndTestResultMessage(TestType type, IExecutionSummary summary
                                        , String buildName, boolean useReportPortal, String url
-                                       , String failedStage = null) {
-  return SlackHelper.renderMessage(
-    [
-      renderBuildResultSection(failedStage)
-      , renderTestResultSection(type, summary, buildName, useReportPortal, url)
-    ]
-  )
+                                       , String failedStage = null, int flakyCount = 0) {
+  List sections = [
+    renderBuildResultSection(failedStage)
+    , renderTestResultSection(type, summary, buildName, useReportPortal, url)
+  ]
+  if (flakyCount > 0) {
+    sections.add(SlackHelper.renderSection("Re-check", "${flakyCount} test(s) promoted to Flaky", "#2eb886", [], []))
+  }
+  return SlackHelper.renderMessage(sections)
 }
 
 Map<Team, String> renderTeamsTestResultMessages(TestType type


### PR DESCRIPTION
## Summary
- Adds `runFailedTestsRecheck()` to `folioCypress` that invokes the `runFailedTests.js` script at the end of Cypress runs, automatically re-verifying "To Investigate" test results and promoting confirmed flaky tests without manual intervention
- Adds `recheckFailedTests` parameter to `folioCypressFlow.call()`; 
  - recheck is gated on `reportPortalUse`, pass rate > 80%, and successful main test phase
- Surfaces `flakyCount` in Slack notifications via an updated `renderBuildAndTestResultMessage()` signature
- Enables recheck in `runNightlyCypressEurekaTests` Jenkinsfiles
- Increases Cypress pod memory request from `2048Mi` to `4096Mi`

## Jira
[RANCHER-2841](https://folio-org.atlassian.net/browse/RANCHER-2841)