### PR TITLE
"RANCHER-3022 idempotent namespace init, skipReindex param, Trillium GA snapshot

### DIFF
--- a/pipelines/folioRancher/folioNamespaceTools/manageNamespace/createNamespaceFromBranch/Jenkinsfile
+++ b/pipelines/folioRancher/folioNamespaceTools/manageNamespace/createNamespaceFromBranch/Jenkinsfile
@@ -28,7 +28,7 @@ properties([
     booleanParam(name: 'SC_NATIVE', defaultValue: true, description: '(Optional) Set false to use Java based SC image'),
     folioParameters.groupParameters('Environment features'
       , ['LOAD_REFERENCE', 'LOAD_SAMPLE', 'BUILD_UI', 'CONSORTIA', 'CONSORTIA_SINGLE_UI', 'CONSORTIA_EXTRA', 'LINKED_DATA', 'MARC_MIGRATIONS', 'RTAC_CACHE',  'EDGE_LOCATE'
-         , 'SPLIT_FILES', 'RW_SPLIT', 'ECS_CCL', 'GREENMAIL', 'MOCK_SERVER', 'RTR', 'DATASET', 'TYPE', 'ENTITLEMENT_APPROACH', 'SET_BASE_URL'
+         , 'SPLIT_FILES', 'RW_SPLIT', 'ECS_CCL', 'GREENMAIL', 'MOCK_SERVER', 'RTR', 'TYPE', 'ENTITLEMENT_APPROACH', 'SET_BASE_URL'
          , 'HAS_SECURE_TENANT', 'SECURE_TENANT'
     ]),
     folioParameters.loadReference(),
@@ -50,12 +50,13 @@ properties([
     booleanParam(name: 'MOCK_SERVER', defaultValue: false, description: '(Optional) Set true to deploy mock-server'),
     booleanParam(name: 'RTR', defaultValue: false, description: '(Optional) Set true to enable RTR'),
     booleanParam(name: 'DATASET', defaultValue: false, description: '(Optional) Set true to build BF like environment'),
+    booleanParam(name: 'SKIP_REINDEX', defaultValue: false, description: '(Optional) Set true to skip triggering search index rebuild'),
     choice(name: 'TYPE', choices: ['full', 'terraform', 'update'], description: '(Required) Set action TYPE to perform'),
     choice(name: 'ENTITLEMENT_APPROACH', choices: ['STATE', 'CREATE'], description: '(Optional) Entitlement method: STATE = PUT /entitlements/state (declarative), CREATE = POST /entitlements (procedural)'),
     booleanParam(name: 'SET_BASE_URL', defaultValue: true, description: '(Optional) Set false to skip PUT /base-url during tenant configuration (e.g. for Sunflower)'),
     string(name: 'DB_BACKUP_NAME', defaultValue: Constants.BUGFEST_SNAPSHOT_NAME, description: '(Optional) Set name of the DB backup to restore'),
     folioParameters.groupParameters('Integrations'
-      , ['POSTGRESQL', 'DB_VERSION', 'KAFKA', 'OPENSEARCH', 'S3_BUCKET', 'DB_BACKUP_NAME']),
+      , ['POSTGRESQL', 'DB_VERSION', 'KAFKA', 'OPENSEARCH', 'SKIP_REINDEX', 'S3_BUCKET', 'DATASET', 'DB_BACKUP_NAME']),
     folioParameters.pgType(),
     folioParameters.pgVersion(),
     folioParameters.kafkaType(),
@@ -125,6 +126,8 @@ CreateNamespaceParameters namespaceParams = new CreateNamespaceParameters.Builde
   .s3Type(params.S3_BUCKET)
   .uiBuild(params.BUILD_UI)
   .dataset(params.DATASET)
+  .skipReindex(params.SKIP_REINDEX)
+  .dbBackupName(params.DB_BACKUP_NAME)
   .type(params.TYPE)
   .scNative(params.SC_NATIVE)
   .initParams(new InitializeFromScratchParameters()

--- a/pipelines/folioRancher/folioScheduledProvisioning/updateSprintTestingEureka/Jenkinsfile
+++ b/pipelines/folioRancher/folioScheduledProvisioning/updateSprintTestingEureka/Jenkinsfile
@@ -31,7 +31,7 @@ properties([
     folioParameters.cluster('PLATFORM'),
     folioParameters.namespace(),
     folioParameters.configType(),
-    string(name: 'DB_BACKUP_NAME', defaultValue: 'folio-bugfest-sunflower-24-02-2026', description: 'Set DB backup name'),
+    string(name: 'DB_BACKUP_NAME', defaultValue: 'folio-bugfest-trillium-16-06-2026-ga', description: 'Set DB backup name'),
     booleanParam(name: 'MARC_MIGRATIONS', defaultValue: false, description: 'enable marc-migrations'),
     choice(name: 'TYPE', choices: ['full', 'terraform', 'update'], description: '(Required) Set action TYPE to perform'),
     booleanParam(name: 'IS_CRON_JOB', defaultValue: false, description: '(Hidden) Is job triggered by cron job'),
@@ -42,8 +42,8 @@ properties([
 //  TODO: Uncomment after Trillium verification ends. ETA - Sprint 242 or 243. Only after notification from @OleksiiPetrenko.
 //  pipelineTriggers([
 //    parameterizedCron('''
-//      H 3 * * 1,2,3,4,5 %PLATFORM=EUREKA;CLUSTER=folio-etesting;NAMESPACE=sprint;CONFIG_TYPE=testing;DB_BACKUP_NAME=folio-bugfest-sunflower-24-02-2026;MARC_MIGRATIONS=true;TYPE=update;IS_CRON_JOB=true
-//      H 0 * * 3 %PLATFORM=EUREKA;CLUSTER=folio-etesting;NAMESPACE=sprint;CONFIG_TYPE=testing;DB_BACKUP_NAME=folio-bugfest-sunflower-24-02-2026;MARC_MIGRATIONS=true;TYPE=full;IS_CRON_JOB=true
+//      H 3 * * 1,2,3,4,5 %PLATFORM=EUREKA;CLUSTER=folio-etesting;NAMESPACE=sprint;CONFIG_TYPE=testing;DB_BACKUP_NAME=folio-bugfest-trillium-16-06-2026-ga;MARC_MIGRATIONS=true;TYPE=update;IS_CRON_JOB=true
+//      H 0 * * 3 %PLATFORM=EUREKA;CLUSTER=folio-etesting;NAMESPACE=sprint;CONFIG_TYPE=testing;DB_BACKUP_NAME=folio-bugfest-trillium-16-06-2026-ga;MARC_MIGRATIONS=true;TYPE=full;IS_CRON_JOB=true
 //    ''')])
 ])
 

--- a/src/org/folio/Constants.groovy
+++ b/src/org/folio/Constants.groovy
@@ -315,7 +315,7 @@ class Constants {
 
   //RDS
   static String BUGFEST_SNAPSHOT_DBNAME = 'folio'
-  static String BUGFEST_SNAPSHOT_NAME = 'folio-bugfest-sunflower-24-02-2026'
+  static String BUGFEST_SNAPSHOT_NAME = 'folio-bugfest-trillium-16-06-2026-ga'
   static String DATA_MIGRATION_SNAPSHOT_NAME = 'folio-general-dataset-april-2025-all-users-clean-v2'
 
   static Map JMX_METRICS_AVAILABLE = ['mod-bulk-operations': '2.0.0-SNAPSHOT.71']

--- a/src/org/folio/models/EurekaTenant.groovy
+++ b/src/org/folio/models/EurekaTenant.groovy
@@ -37,6 +37,8 @@ class EurekaTenant extends OkapiTenant {
   ApplicationList applications = new ApplicationList()
 
   boolean isSecureTenant = false
+  boolean initialized = false
+  boolean indexed = false
 
   EurekaTenant(){}
 
@@ -181,6 +183,22 @@ class EurekaTenant extends OkapiTenant {
     return new EurekaTenant(content.name as String, content.id as String)
       .withTenantName(content.name as String)
       .withTenantDescription(content.description as String) as EurekaTenant
+  }
+
+  @Override
+  public <T extends DTO> T convertTo(Class<T> classTo) {
+    T converted = super.convertTo(classTo)
+    if (converted instanceof EurekaTenant) {
+      converted.initialized = false
+      converted.indexed = false
+    }
+    if (converted instanceof EurekaTenantConsortia) {
+      converted.consortiaInitialized = false
+      converted.centralTenantProvisionedInConsortia = false
+      converted.tenantAddedToConsortia = false
+      converted.shadowAdminConfigured = false
+    }
+    return converted
   }
 
   @NonCPS

--- a/src/org/folio/models/EurekaTenantConsortia.groovy
+++ b/src/org/folio/models/EurekaTenantConsortia.groovy
@@ -21,6 +21,10 @@ class EurekaTenantConsortia extends EurekaTenant {
 
   /** Code associated with the tenant. */
   String tenantCode
+  boolean consortiaInitialized = false
+  boolean centralTenantProvisionedInConsortia = false
+  boolean tenantAddedToConsortia = false
+  boolean shadowAdminConfigured = false
 
   EurekaTenantConsortia(){}
 

--- a/src/org/folio/models/parameters/CreateNamespaceParameters.groovy
+++ b/src/org/folio/models/parameters/CreateNamespaceParameters.groovy
@@ -58,6 +58,7 @@ class CreateNamespaceParameters implements Cloneable {
   boolean uiBuild = true
 
   boolean dataset = false
+  boolean skipReindex = false
 
   boolean scNative = true
 
@@ -295,6 +296,8 @@ class CreateNamespaceParameters implements Cloneable {
      * @return
      */
     Builder dataset(boolean dataset) { return setParam('dataset', dataset) }
+
+    Builder skipReindex(boolean skipReindex) { return setParam('skipReindex', skipReindex) }
 
     /**
      * Specifies the application names list for Eureka platform.

--- a/src/org/folio/rest_v2/PlatformType.groovy
+++ b/src/org/folio/rest_v2/PlatformType.groovy
@@ -1,5 +1,5 @@
 package org.folio.rest_v2
 
 enum PlatformType {
-  OKAPI, EUREKA
+  EUREKA, OKAPI
 }

--- a/src/org/folio/rest_v2/eureka/Eureka.groovy
+++ b/src/org/folio/rest_v2/eureka/Eureka.groovy
@@ -33,6 +33,7 @@ class Eureka extends Base {
 
   Eureka createTenantFlow(EurekaTenant tenant, String cluster, String namespace,
                           InitializeFromScratchParameters params) {
+    // createTenant is expected to be idempotent: returns the existing tenant if already created
     EurekaTenant createdTenant = Tenants.get(kong).createTenant(tenant)
 
     tenant.withUUID(createdTenant.getUuid())
@@ -73,6 +74,7 @@ class Eureka extends Base {
 
     configureTenant(tenant, params)
 
+    tenant.initialized = true
     return this
   }
 
@@ -202,12 +204,20 @@ class Eureka extends Base {
       consortiaTenants.findAll { it.isCentralConsortiaTenant }
 
     centralConsortiaTenants.each { centralConsortiaTenant ->
-      // Create consortia for each central tenant
-      Consortia.get(kong).createConsortia(centralConsortiaTenant)
+      if (centralConsortiaTenant.consortiaInitialized) {
+        logger.info("Consortia '${centralConsortiaTenant.consortiaName}' already configured, skipping.")
+        return
+      }
 
-      Consortia.get(kong)
-        .addCentralConsortiaTenant(centralConsortiaTenant)
-        .checkConsortiaStatus(centralConsortiaTenant, centralConsortiaTenant)
+      if (!centralConsortiaTenant.centralTenantProvisionedInConsortia) {
+        // Create consortia for each central tenant
+        Consortia.get(kong).createConsortia(centralConsortiaTenant)
+
+        Consortia.get(kong)
+          .addCentralConsortiaTenant(centralConsortiaTenant)
+          .checkConsortiaStatus(centralConsortiaTenant, centralConsortiaTenant)
+        centralConsortiaTenant.centralTenantProvisionedInConsortia = true
+      }
 
       // Find institutional tenants for this central tenant
       List<EurekaTenantConsortia> institutionalTenants = consortiaTenants.findAll {
@@ -215,15 +225,23 @@ class Eureka extends Base {
       }
 
       institutionalTenants.each { institutionalTenant ->
-        Consortia.get(kong)
-          .addConsortiaTenant(centralConsortiaTenant, institutionalTenant)
-          .checkConsortiaStatus(centralConsortiaTenant, institutionalTenant)
+        if (!institutionalTenant.tenantAddedToConsortia) {
+          Consortia.get(kong)
+            .addConsortiaTenant(centralConsortiaTenant, institutionalTenant)
+            .checkConsortiaStatus(centralConsortiaTenant, institutionalTenant)
+          institutionalTenant.tenantAddedToConsortia = true
+        }
       }
 
       institutionalTenants.each { institutionalTenant ->
-        Consortia.get(kong)
-          .addRoleToShadowAdminUser(centralConsortiaTenant, institutionalTenant, true)
+        if (!institutionalTenant.shadowAdminConfigured) {
+          Consortia.get(kong)
+            .addRoleToShadowAdminUser(centralConsortiaTenant, institutionalTenant, true)
+          institutionalTenant.shadowAdminConfigured = true
+        }
       }
+
+      centralConsortiaTenant.consortiaInitialized = true
     }
 
     return this
@@ -232,6 +250,10 @@ class Eureka extends Base {
   Eureka initializeFromScratch(Map<String, EurekaTenant> tenants, String cluster, String namespace,
                                boolean enableConsortia, InitializeFromScratchParameters params) {
     tenants.each { tenantId, tenant ->
+      if (tenant.initialized) {
+        logger.info("Tenant '${tenantId}' already initialized, skipping.")
+        return
+      }
       createTenantFlow(tenant, cluster, namespace, params)
     }
 
@@ -243,10 +265,15 @@ class Eureka extends Base {
       )
 
     tenants.each { tenantId, tenant ->
+      if (tenant.indexed) {
+        logger.info("Tenant '${tenantId}' indexes already run, skipping.")
+        return
+      }
       if (tenant.indexes) {
         tenant.indexes.each { index ->
           Indexes.get(kong).runIndexFlow(tenant, index)
         }
+        tenant.indexed = true
       }
     }
 

--- a/src/org/folio/rest_v2/eureka/kong/Indexes.groovy
+++ b/src/org/folio/rest_v2/eureka/kong/Indexes.groovy
@@ -41,7 +41,15 @@ class Indexes extends Kong{
       "indexSettings": []
     ]
 
-    restClient.post(url, body, headers).body
+    try {
+      restClient.post(url, body, headers).body
+    } catch (Exception e) {
+      if (e.getMessage()?.contains('Reindex is already in progress')) {
+        logger.warning("[${tenant.getTenantId()}] Instance reindex is already in progress, skipping: ${e.getMessage()}")
+        return this
+      }
+      throw e
+    }
 
     return this
   }

--- a/terraform/rancher/project/postgresql.tf
+++ b/terraform/rancher/project/postgresql.tf
@@ -555,7 +555,7 @@ EOF
 }
 
 resource "rancher2_secret" "adjust_rds_db" {
-  count        = var.setup_type == "full" && !var.pg_embedded ? 1 : 0
+  count        = contains(["full", "terraform"], var.setup_type) && !var.pg_embedded ? 1 : 0
   name         = "adjust-rds-db"
   project_id   = rancher2_project.this.id
   namespace_id = rancher2_namespace.this.id
@@ -568,7 +568,7 @@ resource "rancher2_secret" "adjust_rds_db" {
 
 
 resource "kubernetes_job_v1" "adjust_rds_db" {
-  count      = var.setup_type == "full" && !var.pg_embedded ? 1 : 0
+  count      = contains(["full", "terraform"], var.setup_type) && !var.pg_embedded ? 1 : 0
   depends_on = [module.rds, rancher2_secret.db-credentials, rancher2_secret.adjust_rds_db]
   provider   = kubernetes
   metadata {

--- a/vars/folioNamespaceCreateEureka.groovy
+++ b/vars/folioNamespaceCreateEureka.groovy
@@ -100,7 +100,7 @@ void call(CreateNamespaceParameters args) {
       tfConfig.addVar('keycloak_version', keycloakVersion)
       tfConfig.addVar('setup_type', args.type)
       if (args.dataset) {
-        tfConfig.addVar('pg_rds_snapshot_name', Constants.BUGFEST_SNAPSHOT_NAME)
+        tfConfig.addVar('pg_rds_snapshot_name', args.dbBackupName ?: Constants.BUGFEST_SNAPSHOT_NAME)
         tfConfig.addVar('pg_dbname', Constants.BUGFEST_SNAPSHOT_DBNAME)
         tfConfig.addVar('pg_instance_type', 'db.r6g.xlarge')
       }
@@ -118,16 +118,17 @@ void call(CreateNamespaceParameters args) {
             break
           case 'terraform':
             folioTerraformFlow.manageNamespace('apply', tfConfig)
-
             currentBuild.result = 'ABORTED'
             currentBuild.description = 'Terraform refresh complete'
-            return
-
             break
           case 'update':
             logger.info("Skip [Terraform] Provision stage")
             break
         }
+      }
+
+      if (args.type == 'terraform') {
+        return
       }
 
       if (args.greenmail) {
@@ -234,8 +235,8 @@ void call(CreateNamespaceParameters args) {
           }
       }
 
-      //In case update environment the reindex is not needed
-      if (args.type == 'update')
+      //In case update environment or reindex skip is requested, the reindex is not needed
+      if (args.type == 'update' || args.skipReindex)
         namespace.getTenants().values().each { tenant -> tenant.indexes.clear() }
 
       // TODO: Move this part to one of Eureka classes later. | DO NOT REMOVE | FIX FOR DNS PROPAGATION ISSUE!!!
@@ -366,6 +367,7 @@ void call(CreateNamespaceParameters args) {
         retry(15) {
           sleep time: (counter == 0 ? 0 : 1), unit: 'MINUTES'
           counter++
+          logger.info("Initialize: retry attempt ${counter} of 15")
 
           eureka.initializeFromScratch(
             namespace.getTenants()


### PR DESCRIPTION
 ## Summary                                                                                                                                                                                              
                                                            
- **Idempotent initialization**: Added `initialized`/`indexed` flags to `EurekaTenant` and consortia state flags (`consortiaInitialized`, `centralTenantProvisionedInConsortia`, `tenantAddedToConsortia`, `shadowAdminConfigured`) to `EurekaTenantConsortia`; overrode `convertTo` to reset them on clone so retries skip already-completed steps
- **Graceful reindex handling**: `Indexes.runIndexFlow` now catches `Reindex is already in progress` and logs a warning instead of failing the pipeline
- **`skipReindex` parameter**: New boolean param in `CreateNamespaceParameters` + `SKIP_REINDEX` Jenkins parameter in `createNamespaceFromBranch/Jenkinsfile`; skips index rebuild when set
- **`dbBackupName` wired through**: Jenkinsfile param is now passed to `pg_rds_snapshot_name` in `folioNamespaceCreateEureka` (falls back to `Constants.BUGFEST_SNAPSHOT_NAME`)
- **Trillium GA snapshot**: Updated `BUGFEST_SNAPSHOT_NAME` → `folio-bugfest-trillium-16-06-2026-ga` in `Constants` and `updateSprintTestingEureka/Jenkinsfile`
- **Terraform fix**: `rancher2_secret.adjust_rds_db` and `kubernetes_job_v1.adjust_rds_db` `count` condition now includes `terraform` setup type (was `full`-only)
- **Minor**: `terraform` type early-return refactored to avoid `return` inside `switch`; retry attempt logging added; `PlatformType` enum reordered (EUREKA first)

## Test plan

- [x] Trigger `createNamespaceFromBranch` with `TYPE=full` and `SKIP_REINDEX=true` — verify reindex stage is skipped
- [x] Trigger with `TYPE=terraform` — verify Terraform apply runs and pipeline exits early (no Helm/init stages)
- [x] Trigger with `DATASET=true` and a custom `DB_BACKUP_NAME` — verify correct snapshot is passed to Terraform
- [x] Confirm `adjust_rds_db` Terraform resources are created for `TYPE=terraform` runs

## Jira

[RANCHER-3022](https://folio-org.atlassian.net/browse/RANCHER-3022)