### PR TITLE
fix(jenkins): align jnlp container memory limit with request

### DIFF
--- a/src/org/folio/jenkins/PodTemplates.groovy
+++ b/src/org/folio/jenkins/PodTemplates.groovy
@@ -108,7 +108,7 @@ spec:
           ttyEnabled: true,
           workingDir: WORKING_DIR,
           resourceRequestMemory: '1024Mi',
-          resourceLimitMemory: '12228Mi',
+          resourceLimitMemory: '1024Mi',
           envVars: [
             new KeyValueEnvVar('JENKINS_JAVA_OPTS',
               '-Dorg.jenkinsci.remoting.engine.JnlpAgentEndpointResolver.PING_INTERVAL=60' +


### PR DESCRIPTION
Reduces jnlp resourceLimitMemory from 12228Mi to 1024Mi to match the existing request. Oversized limits inflate per-pod memory footprint, reducing parallel agent capacity on m6a.2xlarge nodes.