### PR TITLE
RANCHER-2884. Support #branch app resolution in createNamespaceFromBranch

### DIFF
--- a/vars/folioDefault.groovy
+++ b/vars/folioDefault.groovy
@@ -1,6 +1,7 @@
 import org.folio.Constants
 import org.folio.models.*
 import org.folio.rest.GitHubUtility
+import org.folio.utilities.GitHubClient
 
 Map getPlatformDescriptor(String branch = 'snapshot') {
   Map platformDescriptor = new GitHubUtility(this).getJsonModulesList('platform-lsp', branch, 'platform-descriptor.json') as Map
@@ -20,6 +21,18 @@ List<String> getApplicationNamesFromPlatform(String branch = 'snapshot') {
                           (platformDescriptor.applications?.optional?.collect { it.name } ?: [])
 
   return appNames as List<String>
+}
+
+Map getAppDescriptorFromBranch(String appName, String branch) {
+  String content = new GitHubClient(this).getFileContent(branch, 'application.lock.json', appName)
+  if (!content) {
+    throw new Exception("Could not fetch application.lock.json from '${appName}' at branch '${branch}'")
+  }
+
+  Map descriptor = readJSON(text: content) as Map
+  println "Fetched application.lock.json for '${appName}' from branch '${branch}' (${descriptor.modules?.size() ?: 0} modules)"
+
+  return descriptor
 }
 
 List<Map<String, String>> getAllPlatformApps(String branch = 'snapshot', Map platformDescriptor = null) {

--- a/vars/folioNamespaceCreateEureka.groovy
+++ b/vars/folioNamespaceCreateEureka.groovy
@@ -2,6 +2,7 @@ import org.folio.Constants
 import org.folio.far.Far
 import org.folio.jenkins.PodTemplates
 import org.folio.models.*
+import org.folio.models.application.Application
 import org.folio.models.application.ApplicationList
 import org.folio.models.module.FolioModule
 import org.folio.models.parameters.CreateNamespaceParameters
@@ -40,16 +41,28 @@ void call(CreateNamespaceParameters args) {
       Map platformDescriptor = folioDefault.getPlatformDescriptor(args.platformBranch)
       List<Map<String, String>> allPlatformApps = folioDefault.getAllPlatformApps(args.platformBranch, platformDescriptor)
 
-      List<String> appIds = args.applications.collect { appName ->
+      List<Map<String, String>> selectedApps = args.applications.collect { appName ->
         Map<String, String> appEntry = allPlatformApps.find { it.name == appName } as Map<String, String>
         if (!appEntry) {
           throw new Exception("Application '${appName}' not found in platform-descriptor.json")
         }
-        appEntry.name + "-" + appEntry.version
+        appEntry
       }
 
+      List<List<Map<String, String>>> partitioned = selectedApps.split { (it.version as String).startsWith('#') }
+      List<Map<String, String>> branchApps = partitioned[0]
+      List<Map<String, String>> farApps = partitioned[1]
+
       Far far = new Far(this)
-      ApplicationList apps = far.getApplicationsByIds(appIds)
+      ApplicationList apps = far.getApplicationsByIds(farApps.collect { "${it.name}-${it.version}" as String })
+
+      branchApps.each { appEntry ->
+        String branch = (appEntry.version as String).substring(1)
+        Map descriptor = folioDefault.getAppDescriptorFromBranch(appEntry.name as String, branch)
+        apps.add(new Application().withDescriptor(descriptor))
+        logger.info("Resolved application '${appEntry.name}' from GitHub branch '${branch}'")
+      }
+
       FolioInstallJson appModules = apps.getInstallJson()
 
       platformDescriptor['eureka-components']?.each { component ->


### PR DESCRIPTION
## Summary

Adds support for resolving application descriptors from a GitHub branch in the Eureka environment deployment pipeline.

When an application's `version` in `platform-descriptor.json` starts with `#` (e.g. `"version": "#my-feature-branch"`), the pipeline now fetches that app's `application.lock.json` directly from the `folio-org/<app-name>` GitHub repo at the given branch instead of resolving it from FAR. Standard semver versions continue to be resolved through FAR. This lets an environment be deployed with a mix of released apps (FAR) and in-development apps (branch).

## Changes

**`vars/folioDefault.groovy`**
- New method `getAppDescriptorFromBranch(appName, branch)` — fetches and parses `application.lock.json` from `folio-org/<appName>` at the given branch, reusing the existing `GitHubClient.getFileContent(...)` (the GitHub contents API accepts a branch name as `ref`, so no separate branch→SHA lookup is needed). Throws a clear error when the file cannot be fetched.

**`vars/folioNamespaceCreateEureka.groovy`**
- Split application resolution: selected apps are partitioned by whether their `version` starts with `#`. Semver apps go to `Far.getApplicationsByIds(...)`; `#branch` apps are resolved via `getAppDescriptorFromBranch(...)` and added as `Application` objects. Both paths merge into the same `ApplicationList`, so all downstream logic (install JSON, registration, deploy) is unchanged.