### PR TITLE
RANCHER-2936-fix. Remove excessive permissions to the shared envs.

### DIFF
--- a/src/org/folio/models/parameters/DependentParametersResolver.groovy
+++ b/src/org/folio/models/parameters/DependentParametersResolver.groovy
@@ -34,7 +34,7 @@ class DependentParametersResolver {
 
     // Cluster + namespace combined
     result.dataset = resolveDataset(clusterName, namespaceName)
-    result.members = resolveMembers(clusterName, namespaceName)
+    result.members = resolveMembers(namespaceName)
 
     Map overrides = NAMESPACE_OVERRIDES.get(clusterName)?.get(namespaceName) ?: [:]
     result.putAll(overrides)
@@ -76,14 +76,8 @@ class DependentParametersResolver {
     return isPerfCluster && isBugfestNs
   }
 
-  private static final List<String> SHARED_NAMESPACES = ['sprint', 'snapshot', 'snapshot2']
-  private static final List<String> EUREKA_CLUSTERS = ['folio-etesting', 'folio-edev', 'folio-eperf']
-  private static final String SHARED_ENV_MEMBERS = 'thunderjet,folijet,spitfire,vega,thor,Eureka,volaris,corsair,Bama,Aggies,Dreamliner,Leipzig,firebird,dojo,erm'
-
-  private static String resolveMembers(String clusterName, String namespaceName) {
-    if (!clusterName || !namespaceName) return ''
-    if (EUREKA_CLUSTERS.contains(clusterName) && SHARED_NAMESPACES.contains(namespaceName))
-      return SHARED_ENV_MEMBERS
+  private static String resolveMembers(String namespaceName) {
+    if (!namespaceName) return ''
     return Constants.ENVS_MEMBERS_LIST.getOrDefault(namespaceName, '') as String
   }
 


### PR DESCRIPTION
## Summary

Removes excessive Rancher permissions on the shared environments. All FOLIO dev teams were being granted **Project Owner** on `sprint`, `snapshot`, and `snapshot2`; this restores them to read-only.

Ticket: [RANCHER-3035](https://folio-org.atlassian.net/browse/RANCHER-3035)

## Problem

Every dev team (thunderjet, spitfire, vega, thor, volaris, corsair, Bama, Aggies, Dreamliner, Leipzig, firebird, Eureka, folijet, …) appears as **Project Owner** on the shared `folio-etesting` environments `sprint`/`snapshot`/`snapshot2`, letting each team administer the membership and settings of environments it does not own.

## Root cause

`DependentParametersResolver.resolveMembers()` injected the full shared dev-team list (`SHARED_ENV_MEMBERS`) as members of those namespaces. Terraform's project role binding has always bound **every** team in `github_team_ids` with the `project-owner` role, so each injected team became a Project Owner.

The injection was introduced with RANCHER-2936 (#1279). Before it, the member list for these namespaces was empty → no per-team bindings were created, and teams had read-only access only through the cluster-wide `folio-org` binding.

## Change

- Drop the `SHARED_ENV_MEMBERS` / `SHARED_NAMESPACES` / `EUREKA_CLUSTERS` special case from `resolveMembers()`.
- `resolveMembers()` now returns only the `ENVS_MEMBERS_LIST` value, which is empty for `sprint`/`snapshot`/`snapshot2` → no per-team bindings are created.
- Team-owned environments (e.g. `vega`, `thunderjet`) are unaffected — they keep their `project-owner` bindings.

## Impact / rollout

Self-heals on the next scheduled provisioning of sprint (`updateSprintTestingEureka`) and snapshot (`createDailySnapshotEureka`), which will drop the per-team Project Owner bindings. Dev teams keep read-only visibility through the existing cluster-wide `folio-org` read-only binding.
