### PR TITLE
RANCHER-3061: adjustRDSnapshot apt-get upgrade

### DIFF
--- a/scripts/docker/adjustRDSnapshot/Dockerfile
+++ b/scripts/docker/adjustRDSnapshot/Dockerfile
@@ -3,19 +3,17 @@ FROM ubuntu:24.04
 # Set environment variables for non-interactive install
 ENV DEBIAN_FRONTEND=noninteractive
 
-# Update and install prerequisites
-RUN apt-get update && \
-    apt-get install -y wget curl ca-certificates gnupg2 lsb-release && \
-    rm -rf /var/lib/apt/lists/*
-
-# Add PostgreSQL APT repository
-RUN echo "deb http://apt.postgresql.org/pub/repos/apt $(lsb_release -cs)-pgdg main" > /etc/apt/sources.list.d/pgdg.list && \
-    wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | apt-key add -
-
-# Install PostgreSQL 17
-RUN apt-get update && \
-    apt-get install -y postgresql-17 && \
-    rm -rf /var/lib/apt/lists/*
+RUN <<EOF
+apt-get update
+# https://pythonspeed.com/articles/security-updates-in-docker/
+apt-get upgrade -y
+apt-get install -y wget curl ca-certificates gnupg2 lsb-release
+echo "deb http://apt.postgresql.org/pub/repos/apt $(lsb_release -cs)-pgdg main" > /etc/apt/sources.list.d/pgdg.list
+wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | apt-key add -
+apt-get update
+apt-get install -y postgresql-17
+rm -rf /var/lib/apt/lists/*
+EOF
 
 # Expose default PostgreSQL port
 EXPOSE 5432


### PR DESCRIPTION
https://folio-org.atlassian.net/browse/RANCHER-3061

adjustRDSnapshot/Dockerfile doesn’t install security patches for the base image ubuntu:24.04.

Run "apt-get upgrade -y" to install them.

See https://pythonspeed.com/articles/security-updates-in-docker/ for details.

We should also merge all apt-get commands into a single RUN statement to avoid downloading the package list multiple times.