### PR TITLE
RANCHER-3079. Update backup configuration - disable `copy_tags` and add custom tags

### DIFF
--- a/terraform/far/modules/far_postgres_db/backup.tf
+++ b/terraform/far/modules/far_postgres_db/backup.tf
@@ -142,7 +142,10 @@ resource "aws_dlm_lifecycle_policy" "postgres_backup" {
         count = 180 // Retain backups for 180 days
       }
 
-      copy_tags = true
+      copy_tags = false
+      tags_to_add = {
+        Name = "${var.cluster_name}-${var.namespace_name}-postgres-ebs"
+      }
     }
 
     target_tags = {


### PR DESCRIPTION
## Summary

Fixes the FAR postgres backup DLM policy, which was stuck in `ERROR` and had stopped taking daily snapshots (newest restore point had gone ~3 months stale).

## Root cause

The DLM schedule used `copy_tags = true`, so every DLM-created snapshot inherited the source volume's `DeleteProtection = true` tag. The `...-snapshot-protection-policy` attached to the DLM role explicitly **denies** `ec2:DeleteSnapshot` on anything tagged `DeleteProtection=true`. Once retention (`count = 180`) was reached and DLM tried to prune its oldest snapshot, the delete was denied and the **whole policy halted** — no more backups were created.

```
not authorized to perform: ec2:DeleteSnapshot on ... snap-... 
explicit deny in an identity-based policy ... snapshot-protection-policy
```

## Change

- `copy_tags = false` — DLM dailies no longer inherit `DeleteProtection`, so DLM can prune its own aged snapshots and the policy stays healthy.
- `tags_to_add = { Name = "${cluster}-${namespace}-postgres-ebs" }` — keeps snapshots identifiable by the same `Name` used for filtering/targeting, without the protection tag.

The `snapshot-protection-policy` is intentionally left in place — it still guards *manually*-tagged restore points (which DLM never manages), just not the routine dailies.

## Live remediation (already applied out-of-band)

The live policy and existing snapshots were repaired via AWS CLI so backups resume immediately (no `terraform apply` was run for FAR — its state is stale and will be reconciled separately):

- Took a fresh on-demand restore point of the FAR postgres volume.
- Stripped `DeleteProtection` from the 182 existing DLM snapshots so pruning can proceed.
- Updated the live DLM policy to `CopyTags=false` + `TagsToAdd=Name` and reset it `ERROR → ENABLED`.

This PR brings `backup.tf` in line with that live config, so the eventual FAR state-align `apply` shows no drift on this resource.

Ref: RANCHER-3079
