### PR TITLE
RANCHER-2878. WS5: Custom UI module support in Jenkins pipelines

### DIFF
--- a/pipelines/v2/modules/buildPush/Jenkinsfile
+++ b/pipelines/v2/modules/buildPush/Jenkinsfile
@@ -2,7 +2,6 @@ package v2.modules.buildPush
 
 import org.folio.Constants
 import org.folio.jenkins.PodTemplates
-import org.folio.models.module.EurekaModule
 import org.folio.models.module.FolioModule
 import org.folio.models.module.ModuleBuildTool
 import org.folio.models.module.ModuleType
@@ -161,7 +160,7 @@ void buildAndPublishUiModuleDescriptor(String moduleName, String branch, Logger 
       return
     }
 
-    EurekaModule module = new EurekaModule()
+    FolioModule module = new FolioModule()
     container('node') {
       dir(moduleName) {
         Map packageJson = readJSON(file: 'package.json')

--- a/pipelines/v2/modules/buildPush/Jenkinsfile
+++ b/pipelines/v2/modules/buildPush/Jenkinsfile
@@ -182,6 +182,9 @@ void buildAndPublishUiModuleDescriptor(String moduleName, String branch, Logger 
 
         def generated = readJSON(file: 'module-descriptors.json')
         def descriptor = (generated instanceof List) ? generated[0] : generated
+        if (!descriptor?.id) {
+          error("stripes mod descriptor produced no valid descriptor (missing id) for ${moduleName}")
+        }
         writeJSON file: 'module-descriptor.json', json: descriptor, pretty: 2
 
         module.loadModuleDetails(descriptor.id as String)
@@ -211,7 +214,7 @@ void uploadModuleDescriptor(FolioModule module) {
   sh(
     label: "Upload Module Descriptor to Module Registry",
     returnStdout: false,
-    script: "[ -e ${module.modDescriptorPath} ] && curl -sS -X PUT ${Constants.EUREKA_REGISTRY_DESCRIPTORS_URL}${module.name}-${module.version} --upload-file ${module.modDescriptorPath}"
+    script: "[ -e ${module.modDescriptorPath} ] && curl -sS --retry 3 --retry-delay 5 --retry-connrefused --connect-timeout 30 -X PUT ${Constants.EUREKA_REGISTRY_DESCRIPTORS_URL}${module.name}-${module.version} --upload-file ${module.modDescriptorPath}"
   )
 }
 

--- a/pipelines/v2/modules/buildPush/Jenkinsfile
+++ b/pipelines/v2/modules/buildPush/Jenkinsfile
@@ -2,6 +2,7 @@ package v2.modules.buildPush
 
 import org.folio.Constants
 import org.folio.jenkins.PodTemplates
+import org.folio.models.module.EurekaModule
 import org.folio.models.module.FolioModule
 import org.folio.models.module.ModuleBuildTool
 import org.folio.models.module.ModuleType
@@ -17,7 +18,7 @@ properties([
   buildDiscarder(logRotator(numToKeepStr: '10')),
   parameters([
     folioParameters.platform(),
-    folioParameters.moduleName(), // MODULE_NAME, Folio Module moduleName
+    folioParameters.moduleName('PLATFORM', 'MODULE_NAME', true), // MODULE_NAME - includeUi=true so UI modules are selectable
     folioParameters.branchWithRef('MODULE_BRANCH', 'MODULE_NAME'), // MODULE_BRANCH, Module Github branch
     string(name: 'MAVEN_ARGS', defaultValue: '-DskipTests', description: 'Maven build arguments'),
     choice(name: 'JAVA_VERSION', choices: ['21', '17'], description: 'Java version to use for tests'),
@@ -35,14 +36,23 @@ if (params.REFRESH_PARAMETERS) {
 PodTemplates podTemplates = new PodTemplates(this, true)
 Logger logger = new Logger(this, env.JOB_BASE_NAME)
 
+String moduleName = params.MODULE_NAME
+String branch = params.MODULE_BRANCH
+ModuleType moduleType = ModuleType.determineModuleType(moduleName)
+
 ansiColor('xterm') {
-  podTemplates.javaBuildAgent(params.JAVA_VERSION) {
-    String moduleName = params.MODULE_NAME
-    String branch = params.MODULE_BRANCH
-    String mavenArgs = params.MAVEN_ARGS.trim()
-    String gradleOpts = '--quiet --console plain --no-daemon'
+  if (moduleType == ModuleType.FRONTEND) {
+    podTemplates.stripesLightweightAgent {
+      buildAndPublishUiModuleDescriptor(moduleName, branch, logger)
+    }
+  } else {
+    podTemplates.javaBuildAgent(params.JAVA_VERSION) {
+      buildAndPushBackendModule(moduleName, branch, params.MAVEN_ARGS.trim(), '--quiet --console plain --no-daemon', logger)
+    }
+  }
+}
 
-
+void buildAndPushBackendModule(String moduleName, String branch, String mavenArgs, String gradleOpts, Logger logger) {
     FolioModule module = new FolioModule()
     String commitHash = ""
     String args = ""
@@ -118,17 +128,91 @@ Build tool: ${module.buildTool.toString()}"""
 
         module.descriptor = [readJSON(file: module.modDescriptorPath)]
 
-        sh(
-          label: "Upload Module Descriptor to Module Registry",
-          returnStdout: false,
-          script: "[ -e ${module.modDescriptorPath} ] && curl -sS -X PUT ${Constants.EUREKA_REGISTRY_DESCRIPTORS_URL}${module.name}-${module.version} --upload-file ${module.modDescriptorPath}"
-        )
+        uploadModuleDescriptor(module)
 
         zip zipFile: "ModuleDescriptor.json.zip", glob: "**/ModuleDescriptor.json"
         archiveArtifacts allowEmptyArchive: true, artifacts: "ModuleDescriptor.json.zip", fingerprint: true, defaultExcludes: false
       }
     }
+}
+
+/**
+ * Builds and publishes a UI (Stripes) module descriptor to the Eureka registry (S3).
+ * UI modules have no jar/image - the descriptor is generated from the module's package.json
+ * via @folio/stripes-cli.
+ */
+void buildAndPublishUiModuleDescriptor(String moduleName, String branch, Logger logger) {
+  stage('[Git] Checkout module source') {
+    checkout([
+      $class           : 'GitSCM',
+      branches         : [[name: "*/${branch}"]],
+      extensions       : [[$class: 'RelativeTargetDirectory', relativeTargetDir: moduleName],
+                          [$class: 'CleanBeforeCheckout', deleteUntrackedNestedRepositories: true],
+                          [$class: 'AuthorInChangelog'],
+                          [$class: 'SubmoduleOption', recursiveSubmodules: true]],
+      userRemoteConfigs: [[url: "https://github.com/folio-org/${moduleName}.git"]]
+    ])
   }
+
+  stage('[Yarn] Generate & publish module descriptor') {
+    if (!params.PUSH_DESCRIPTOR_TO_ECR) {
+      logger.info("Skip [Yarn] Generate & publish module descriptor stage")
+      Utils.markStageSkippedForConditional('[Yarn] Generate & publish module descriptor')
+      return
+    }
+
+    EurekaModule module = new EurekaModule()
+    container('node') {
+      dir(moduleName) {
+        Map packageJson = readJSON(file: 'package.json')
+        String cliVersion = packageJson.devDependencies?.getAt('@folio/stripes-cli') ?: 'latest'
+
+        sh(
+          label: 'Generate module descriptor via stripes-cli',
+          script: """
+            export HOME=\$(pwd)
+            yarn config set @folio:registry ${Constants.FOLIO_NPM_REPO_URL}
+            cp package.json package.json.orig
+            rm package.json
+            yarn add @folio/stripes-cli@${cliVersion}
+            mv package.json.orig package.json
+            yarn --silent stripes mod descriptor --full --strict > module-descriptors.json
+          """.stripIndent().trim()
+        )
+
+        def generated = readJSON(file: 'module-descriptors.json')
+        def descriptor = (generated instanceof List) ? generated[0] : generated
+        writeJSON file: 'module-descriptor.json', json: descriptor, pretty: 2
+
+        module.loadModuleDetails(descriptor.id as String)
+        module.descriptor = [descriptor]
+      }
+    }
+
+    module.modDescriptorPath = "${moduleName}/module-descriptor.json"
+    uploadModuleDescriptor(module)
+
+    buildName "${moduleName}.${env.BUILD_ID}"
+    buildDescription """Module: ${module.id}
+Branch: ${branch}
+Type: UI (Stripes)"""
+
+    writeJSON file: 'execution_results.json', json: [
+      moduleId: module.id
+    ] // Export module ID to be used in the upstream jobs. DO NOT REMOVE!!!
+    archiveArtifacts allowEmptyArchive: true, artifacts: "execution_results.json", fingerprint: true, defaultExcludes: false
+
+    zip zipFile: "module-descriptor.json.zip", glob: "**/module-descriptor.json"
+    archiveArtifacts allowEmptyArchive: true, artifacts: "module-descriptor.json.zip", fingerprint: true, defaultExcludes: false
+  }
+}
+
+void uploadModuleDescriptor(FolioModule module) {
+  sh(
+    label: "Upload Module Descriptor to Module Registry",
+    returnStdout: false,
+    script: "[ -e ${module.modDescriptorPath} ] && curl -sS -X PUT ${Constants.EUREKA_REGISTRY_DESCRIPTORS_URL}${module.name}-${module.version} --upload-file ${module.modDescriptorPath}"
+  )
 }
 
 void compile(FolioModule module, String args) {
@@ -221,7 +305,7 @@ def buildAndPushImage(FolioModule module, String args) {
           String shellCmd = """
             echo '[INFO] Build Container Image'
             ./gradlew ${args} -PdockerRepo=folioci -PappVersion=${module.version} buildImage
-  
+
             echo '[INFO] Get rid of BUILD_NUMBER in Module Descriptor'
             [ -e ${module.modDescriptorPath} ] && sed -i 's#${module.version}.${env.BUILD_NUMBER}#${module.version}#g' ${module.modDescriptorPath}
           """.stripIndent().trim()
@@ -235,7 +319,7 @@ def buildAndPushImage(FolioModule module, String args) {
 
           withAWS(credentials: Constants.ECR_FOLIO_REPOSITORY_CREDENTIALS_ID, region: Constants.AWS_REGION) {
             sh """
-              set +x 
+              set +x
               ${ecrLogin()}
             """
             docker.withRegistry("https://${Constants.ECR_FOLIO_REPOSITORY}") {

--- a/pipelines/v2/modules/buildPush/Jenkinsfile
+++ b/pipelines/v2/modules/buildPush/Jenkinsfile
@@ -167,18 +167,20 @@ void buildAndPublishUiModuleDescriptor(String moduleName, String branch, Logger 
         Map packageJson = readJSON(file: 'package.json')
         String cliVersion = packageJson.devDependencies?.getAt('@folio/stripes-cli') ?: 'latest'
 
-        sh(
-          label: 'Generate module descriptor via stripes-cli',
-          script: """
-            export HOME=\$(pwd)
-            yarn config set @folio:registry ${Constants.FOLIO_NPM_REPO_URL}
-            cp package.json package.json.orig
-            rm package.json
-            yarn add @folio/stripes-cli@${cliVersion}
-            mv package.json.orig package.json
-            yarn --silent stripes mod descriptor --full --strict > module-descriptors.json
-          """.stripIndent().trim()
-        )
+        withEnv(["STRIPES_CLI_VERSION=${cliVersion}"]) {
+          sh(
+            label: 'Generate module descriptor via stripes-cli',
+            script: """
+              export HOME=\$(pwd)
+              yarn config set @folio:registry ${Constants.FOLIO_NPM_REPO_URL}
+              cp package.json package.json.orig
+              rm package.json
+              yarn add "@folio/stripes-cli@\${STRIPES_CLI_VERSION}"
+              mv package.json.orig package.json
+              yarn --silent stripes mod descriptor --full --strict > module-descriptors.json
+            """.stripIndent().trim()
+          )
+        }
 
         def generated = readJSON(file: 'module-descriptors.json')
         def descriptor = (generated instanceof List) ? generated[0] : generated

--- a/src/org/folio/jenkins/PodTemplates.groovy
+++ b/src/org/folio/jenkins/PodTemplates.groovy
@@ -279,6 +279,37 @@ spec:
   }
 
   /**
+   * Builds a lightweight Node.js container for running Stripes CLI tooling
+   * (e.g. generating a UI module descriptor). No browsers/test tooling - much lighter than Cypress.
+   *
+   * @param extraEnvVars Optional environment variables.
+   * @param resourceRequestMemory Minimum memory request (default {@code 512Mi}).
+   * @param resourceLimitMemory Memory limit (default {@code 2Gi}).
+   * @return Node container definition.
+   */
+  private Object buildNodeContainer(
+    List<KeyValueEnvVar> extraEnvVars = [],
+    String resourceRequestMemory = '512Mi',
+    String resourceLimitMemory = '2Gi'
+  ) {
+    return steps.containerTemplate(
+      name: 'node',
+      image: "${ECR_REPOSITORY}/node:22-alpine",
+      alwaysPullImage: true,
+      command: 'sleep',
+      args: '99d',
+      envVars: [
+        new KeyValueEnvVar('HOME', WORKING_DIR),
+        new KeyValueEnvVar('YARN_CACHE_FOLDER', "${WORKING_DIR}/.yarn/cache")
+      ] + extraEnvVars,
+      runAsGroup: '1000',
+      runAsUser: '1000',
+      resourceRequestMemory: resourceRequestMemory,
+      resourceLimitMemory: resourceLimitMemory
+    )
+  }
+
+  /**
    * Creates a customized pod template and executes a pipeline body inside.
    *
    * @param config Configuration object defining the template (volumes, containers, yaml, etc.).
@@ -379,6 +410,27 @@ spec:
 """,
       containers: [
         buildWerfContainer([], '10Gi', '10Gi'),
+      ]
+    )) {
+      steps.node(JenkinsAgentLabel.STRIPES_AGENT.getLabel()) {
+        body.call()
+      }
+    }
+  }
+
+  /**
+   * Defines a lightweight Stripes agent for module-level Node.js tooling (e.g. generating a UI
+   * module descriptor via @folio/stripes-cli). Reuses the Stripes agent label (node group) but
+   * provides only a Node container instead of Werf - no ui-bundle build tooling.
+   *
+   * @param body Pipeline steps to execute inside this agent.
+   */
+  void stripesLightweightAgent(Closure body) {
+    createTemplate(new PodTemplateConfig(
+      label: JenkinsAgentLabel.STRIPES_AGENT.getLabel(),
+      volumes: [steps.persistentVolumeClaim(claimName: YARN_CACHE_PVC, mountPath: "${WORKING_DIR}/.yarn/cache")],
+      containers: [
+        buildNodeContainer()
       ]
     )) {
       steps.node(JenkinsAgentLabel.STRIPES_AGENT.getLabel()) {

--- a/src/org/folio/models/module/ModuleType.groovy
+++ b/src/org/folio/models/module/ModuleType.groovy
@@ -18,6 +18,8 @@ enum ModuleType {
         return EDGE
       case ~/^folio_.*/:
         return FRONTEND
+      case ~/^ui-.*/:
+        return FRONTEND
       case ~/^mgr-.*/:
         return MGR
       case ~/.*sidecar.*/:

--- a/src/org/folio/rest_v2/eureka/Eureka.groovy
+++ b/src/org/folio/rest_v2/eureka/Eureka.groovy
@@ -7,6 +7,7 @@ import org.folio.models.application.Application
 import org.folio.models.application.ApplicationList
 import org.folio.models.module.EurekaModule
 import org.folio.models.module.FolioModule
+import org.folio.models.module.ModuleType
 import org.folio.models.parameters.InitializeFromScratchParameters
 import org.folio.rest_v2.EntitlementApproach
 import org.folio.rest_v2.eureka.kong.*
@@ -450,11 +451,15 @@ class Eureka extends Base {
     appDescriptor.version = newAppVersion
     appDescriptor.id = "${appDescriptor.name}-${newAppVersion}"
 
+    // UI (Stripes) modules live under uiModules/uiModuleDescriptors; backend/edge under modules/moduleDescriptors.
+    String modulesKey = module.type == ModuleType.FRONTEND ? 'uiModules' : 'modules'
+    String descriptorsKey = module.type == ModuleType.FRONTEND ? 'uiModuleDescriptors' : 'moduleDescriptors'
+
     // Remove any URL links from previous module updates
-    appDescriptor['modules'].each { it.containsKey('url') ? it.remove('url') : '' }
+    appDescriptor[modulesKey].each { it.containsKey('url') ? it.remove('url') : '' }
 
     // Update Application Descriptor with new Module Version
-    for (item in appDescriptor['modules']) {
+    for (item in appDescriptor[modulesKey]) {
       if (item['name'] == module.name) {
         /** Module ID to update */
         String staleModuleId = item['id'] // save stale module id for descriptor removal
@@ -466,10 +471,10 @@ class Eureka extends Base {
         logger.info("Updated Module info:\n${item}")
 
         // Remove stale module descriptor from Updated Application Descriptor
-        for (descriptor in appDescriptor['moduleDescriptors']) {
+        for (descriptor in (appDescriptor[descriptorsKey] ?: [])) {
           if (descriptor['id'] == staleModuleId) {
             logger.info("Removing stale module descriptor \"${descriptor['id']}\" from Updated Application Descriptor")
-            appDescriptor['moduleDescriptors'].remove(descriptor)
+            appDescriptor[descriptorsKey].remove(descriptor)
             break
           }
         }

--- a/src/org/folio/rest_v2/eureka/Eureka.groovy
+++ b/src/org/folio/rest_v2/eureka/Eureka.groovy
@@ -451,7 +451,7 @@ class Eureka extends Base {
     appDescriptor.version = newAppVersion
     appDescriptor.id = "${appDescriptor.name}-${newAppVersion}"
 
-    // UI (Stripes) modules live under uiModules/uiModuleDescriptors; backend/edge under modules/moduleDescriptors.
+    // UI modules live under uiModules/uiModuleDescriptors; backend/edge under modules/moduleDescriptors.
     String modulesKey = module.type == ModuleType.FRONTEND ? 'uiModules' : 'modules'
     String descriptorsKey = module.type == ModuleType.FRONTEND ? 'uiModuleDescriptors' : 'moduleDescriptors'
 

--- a/src/org/folio/rest_v2/eureka/Eureka.groovy
+++ b/src/org/folio/rest_v2/eureka/Eureka.groovy
@@ -456,10 +456,10 @@ class Eureka extends Base {
     String descriptorsKey = module.type == ModuleType.FRONTEND ? 'uiModuleDescriptors' : 'moduleDescriptors'
 
     // Remove any URL links from previous module updates
-    appDescriptor[modulesKey].each { it.containsKey('url') ? it.remove('url') : '' }
+    (appDescriptor[modulesKey] ?: []).each { it.containsKey('url') ? it.remove('url') : '' }
 
     // Update Application Descriptor with new Module Version
-    for (item in appDescriptor[modulesKey]) {
+    for (item in (appDescriptor[modulesKey] ?: [])) {
       if (item['name'] == module.name) {
         /** Module ID to update */
         String staleModuleId = item['id'] // save stale module id for descriptor removal

--- a/vars/folioParameters.groovy
+++ b/vars/folioParameters.groovy
@@ -211,8 +211,8 @@ def referenceTenantId(String tenant_id = 'diku') {
   return _paramString('REFERENCE_TENANT_ID', tenant_id, 'Reference Id used for tenant creation')
 }
 
-def moduleName(String reference = 'PLATFORM', String paramName = 'MODULE_NAME') {
-  return _paramExtendedSingleSelect(paramName, reference, folioStringScripts.getModulesList("\${${reference}}"), 'Select module name to install')
+def moduleName(String reference = 'PLATFORM', String paramName = 'MODULE_NAME', boolean includeUi = false) {
+  return _paramExtendedSingleSelect(paramName, reference, folioStringScripts.getModulesList("\${${reference}}", includeUi), 'Select module name to install')
 }
 
 def moduleType() {

--- a/vars/folioStringScripts.groovy
+++ b/vars/folioStringScripts.groovy
@@ -215,7 +215,7 @@ def fetchAllModules(String initialUrl, String token) {
 
 def filterModules(List<String> modules, String platform) {
   modules.findAll { name ->
-    def isStandardModule = name.startsWith('mod-') || name.startsWith('edge-')
+    def isStandardModule = name.startsWith('mod-') || name.startsWith('edge-') || name.startsWith('ui-')
     def isOkapiSpecific = name == 'okapi'
     def isEurekaSpecific = ['folio-kong', 'folio-keycloak', 'folio-module-sidecar'].contains(name) || name.startsWith('mgr-')
 

--- a/vars/folioStringScripts.groovy
+++ b/vars/folioStringScripts.groovy
@@ -159,7 +159,7 @@ static String getModuleId(String moduleName) {
   }
 }
 
-static String getModulesList(String reference){
+static String getModulesList(String reference, boolean includeUi = false){
   return """import groovy.json.JsonSlurperClassic
 import com.cloudbees.plugins.credentials.CredentialsProvider
 import org.jenkinsci.plugins.plaincredentials.StringCredentials
@@ -213,9 +213,9 @@ def fetchAllModules(String initialUrl, String token) {
   return modules
 }
 
-def filterModules(List<String> modules, String platform) {
+def filterModules(List<String> modules, String platform, boolean includeUi) {
   modules.findAll { name ->
-    def isStandardModule = name.startsWith('mod-') || name.startsWith('edge-') || name.startsWith('ui-')
+    def isStandardModule = name.startsWith('mod-') || name.startsWith('edge-')
     def isOkapiSpecific = name == 'okapi'
     def isEurekaSpecific = ['folio-kong', 'folio-keycloak', 'folio-module-sidecar'].contains(name) || name.startsWith('mgr-')
 
@@ -226,6 +226,9 @@ def filterModules(List<String> modules, String platform) {
     if (platform?.toUpperCase() == 'EUREKA') {
       result = result || isEurekaSpecific
     }
+    if (includeUi) {
+      result = result || name.startsWith('ui-')
+    }
     return result
   }.sort()
 }
@@ -234,11 +237,12 @@ def apiUrl = "https://api.github.com/orgs/folio-org/repos"
 def perPage = 100
 def credentialId = "github-jenkins-service-user-token"
 def platform = "${reference}" // Provided at runtime
+def includeUi = ${includeUi}   // Injected at generation time; only buildPush opts in
 
 try {
   def token = getGithubToken(credentialId)
   def modules = fetchAllModules("\${apiUrl}?per_page=\${perPage}", token)
-  def filteredModules = filterModules(modules, platform)
+  def filteredModules = filterModules(modules, platform, includeUi)
 
   return filteredModules
 } catch (Exception e) {


### PR DESCRIPTION
## Summary

WS5 of [RANCHER-2875](https://folio-org.atlassian.net/browse/RANCHER-2875) (Custom & Optional Applications in CI/CD). Adds support for building and publishing a **custom UI (Stripes) module descriptor** from a feature branch, so the `folio-application-generator` can resolve it from the S3 registry (`EUREKA_REGISTRY_DESCRIPTORS_URL`) when building app descriptors that pin a UI module to a branch/commit.

UI module descriptors are **generated, not committed** (`@folio/stripes-cli` → `stripes mod descriptor --full --strict`), and nothing in our pipelines published them. This extends `buildPush` to do that — **no Docker image and no jar** for UI.

## Changes

**`pipelines/v2/modules/buildPush/Jenkinsfile`**
- Dispatch on `ModuleType.determineModuleType(MODULE_NAME)`: `FRONTEND` → lightweight Node agent + UI descriptor flow; backend/edge/etc. → the existing Java build (unchanged, extracted into `buildAndPushBackendModule`).
- UI flow: checkout the module, generate the descriptor with stripes-cli (installs **only** stripes-cli, not the module's deps), then PUT it to `EUREKA_REGISTRY_DESCRIPTORS_URL` via the shared `uploadModuleDescriptor` helper. Generation runs in `container('node')`; the `curl` upload runs on the default agent container (`node:22-alpine` has no curl).
- `MODULE_NAME` lists UI modules for this pipeline (`includeUi = true`).

**`src/org/folio/jenkins/PodTemplates.groovy`**
- `buildNodeContainer()` — lightweight `node:22-alpine` (ECR-mirrored) container.
- `stripesLightweightAgent()` — Node-only pod that **reuses the existing `stripes-agent` label / node group**, kept separate from `stripesAgent` so `folioUI` ui-bundle builds are unaffected.

**`src/org/folio/models/module/ModuleType.groovy`** — `ui-*` classified as `FRONTEND`.

**`vars/folioStringScripts.groovy` / `vars/folioParameters.groovy`** — `getModulesList` / `filterModules` / `moduleName` gain an `includeUi` opt-in (default `false`). Only `buildPush` sets it, so UI modules do **not** appear in the deploy pipelines' module dropdowns (platform-independent — environments are effectively always Eureka).

## Deployment note

`buildNodeContainer` references `${ECR}/node:22-alpine`; that image was mirrored into ECR (repository `node`, tag `22-alpine`).

Ticket: [RANCHER-2878](https://folio-org.atlassian.net/browse/RANCHER-2878)
