### PR TITLE
fix: split and parse sidecar access logs

### DIFF
--- a/terraform/rancher/cluster/logging.tf
+++ b/terraform/rancher/cluster/logging.tf
@@ -353,7 +353,7 @@ data:
       # Multiline configuration to handle various log formats
       # Match lines that start with timestamp patterns or are continuations
       multiline.type: pattern
-      multiline.pattern: '^(\d{4}-\d{2}-\d{2}[T ]|\d{2}:\d{2}:\d{2}|\[[\d-]+\s+\d{2}:\d{2}:\d{2}|[\d.]+\s+-\s+|\{"log":)'
+      multiline.pattern: '^(\d{4}-\d{2}-\d{2}[T ]|\d{2}:\d{2}:\d{2}|\[[\d-]+\s+\d{2}:\d{2}:\d{2}|[\w.:\[\]-]+(?:,[[:space:]]*[\w.:\[\]-]+)*[[:space:]]+-[[:space:]]+[\w.:\[\]-]+:\d+[[:space:]]+-[[:space:]]+\[\d{2}/\d{2}/\d{4}:\d{2}:\d{2}:\d{2}[[:space:]]+[^\]]+\][[:space:]]+"\S+[[:space:]]+/[^"]*[[:space:]]+HTTP_[12](_[0-9]+)?"[[:space:]]+[0-9]{3}[[:space:]]+[0-9]+[[:space:]]+rt=|[[:space:]]*-[[:space:]]+-[[:space:]]+\[\d{2}/\d{2}/\d{4}:\d{2}:\d{2}:\d{2}[[:space:]]+[^\]]+\][[:space:]]+"|[\d.]+\s+-\s+|\{"log":)'
       multiline.negate: true
       multiline.match: after
       multiline.max_lines: 10000
@@ -427,7 +427,7 @@ data:
           ignore_failure: true
           when:
             regexp:
-              log: '^[\d.:.]+ - [\w.:]+:\d+ -  \[\d{2}/\d{2}/\d{4}:\d{2}:\d{2}:\d{2} GMT\] "[\w]+ /'
+              log: '^[\w.:\[\]-]+(?:,[[:space:]]*[\w.:\[\]-]+)*[[:space:]]+-[[:space:]]+[\w.:\[\]-]+:\d+[[:space:]]+-[[:space:]]+\[\d{2}/\d{2}/\d{4}:\d{2}:\d{2}:\d{2}[[:space:]]+[^\]]+\][[:space:]]+"\S+[[:space:]]+/'
       # Parse FOLIO sidecar application logs (Java logs from sidecar)
       - dissect:
           tokenizer: "%%{timestamp} %%{level} [%%{logger}] (%%{thread}) %%{message}"


### PR DESCRIPTION
## Summary

- Extend Filebeat multiline boundaries for FOLIO sidecar access logs.
- Support local and forwarded client addresses, module names with hyphens, and HTTP/2.
- Align the sidecar access-log dissect condition with the supported formats.

## Root cause

Sidecar access-log lines were not recognized as new events by the multiline boundary pattern. They could therefore be appended to the preceding application log or stack trace.

## Validation

- Filebeat 7.17.15: configuration check passed with `Config OK`.
- Filebeat 7.17.15 runtime sample: local access, forwarded access, and HTTP/2 records were emitted as separate events; Java stack trace and SQL continuation remained multiline.
- Terraform 1.6.6: `fmt -check` passed.
- Regex smoke checks passed for the observed log formats.
- Gradle tests were not run because the local environment has no Java Runtime.