### PR TITLE
RANCHER-3080. Align FAR terraform state with live deployment

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,3 @@
+# Helm values templates are rendered into terraform state, so their line endings must not
+# depend on the operator's checkout - otherwise plan shows a whitespace-only diff.
+*.tmpl text eol=lf

--- a/terraform/far/modules/far_postgres_db/main.tf
+++ b/terraform/far/modules/far_postgres_db/main.tf
@@ -49,10 +49,9 @@ resource "helm_release" "postgres" {
   cleanup_on_fail = true
   values          = [local.helm_values]
 
-  atomic       = true
-  timeout      = var.helm_timeout
-  wait         = true
-  force_update = true
+  atomic  = true
+  timeout = var.helm_timeout
+  wait    = true
 
   depends_on = [
     kubernetes_persistent_volume_claim.postgres

--- a/terraform/far/modules/far_postgres_db/values.yaml.tmpl
+++ b/terraform/far/modules/far_postgres_db/values.yaml.tmpl
@@ -3,10 +3,8 @@ global:
     allowInsecureImages: true
 
 image:
-#  registry: 732722833398.dkr.ecr.us-west-2.amazonaws.com
-#  repository: postgresql
+  registry: public.ecr.aws
   tag: 16.4.0
-#  pullPolicy: IfNotPresent
 
 auth:
   postgresPassword: "${db_password}"
@@ -41,11 +39,8 @@ primary:
 
 volumePermissions:
   enabled: true
-#  image:
-#    registry: 732722833398.dkr.ecr.us-west-2.amazonaws.com
-#    repository: os-shell
-#    tag: 11-debian-11-r91
-#    pullPolicy: IfNotPresent
+  image:
+    registry: public.ecr.aws
 
 audit:
   enabled: true


### PR DESCRIPTION
## Why

The FAR terraform state (`s3://folio-terraform/far/terraform.tfstate`) had not been written since 2025-09-21. A `plan` against it reported two in-place helm release updates with `values` masked as `(sensitive value)` — and applying it as-is would have taken the FAR database down.

Two independent problems were hiding behind that masked diff.

**1. The postgres release renders images that no longer exist.** `docker.io/bitnami/postgresql:16.4.0` and `docker.io/bitnami/os-shell:12-debian-12-r49` both return 404 since Bitnami's 2025-08-28 Docker Hub purge (only `bitnamilegacy/*` survives). The live StatefulSet had been patched by hand on 2025-10-18, via the Rancher UI, to `public.ecr.aws/bitnami/*` to keep the pod running — a registry move, not a version change, `16.4.0` on both sides, which is why it is easy to miss. Helm computes its patch as diff(live -> newly rendered manifest) with `overwrite=true`, so any upgrade of this release — even a whitespace-only one — would have pushed the dead image back. `force_update = true` escalated that from a patch to a StatefulSet replacement, and `atomic = true` would have rolled back onto the same broken manifest.

**2. The diff itself was whitespace.** The `values` stored in state were rendered from CRLF templates, while a Linux checkout renders LF. The repo has `core.autocrlf = input` and no `.gitattributes`, so rendered helm values depended on who checked out the tree. After LF normalisation, the state's values and a fresh render were byte-identical — the postgres release was about to be upgraded, and the database put at risk, for nothing.

## Changes

**`terraform/far/modules/far_postgres_db/values.yaml.tmpl`** — pin `image.registry` and `volumePermissions.image.registry` to `public.ecr.aws`, replacing a stale commented-out private-ECR block (its `os-shell` tag `11-debian-11-r91` was from a different chart version). This makes the rendered manifest match what actually runs. No tag is pinned for `os-shell`: chart 16.7.21 already defaults to `12-debian-12-r49`, which is the live tag, and pinning it would strand the init container on an old image at the next chart bump.

**`terraform/far/modules/far_postgres_db/main.tf`** — drop `force_update = true` from `helm_release.postgres`. A database is the one resource where replace-instead-of-patch is never wanted; `RECOVERY.md` already prescribes `terraform taint` for deliberate force-convergence, so the flag is not load-bearing. The mgr release keeps it, being stateless.

**`.gitattributes`** — `*.tmpl text eol=lf`. Root cause fix: helm values templates are rendered into terraform state, so their line endings must not depend on the operator's checkout.