### PR TITLE
RANCHER-2519. Safer Platform State File Update Mechanism.

### DIFF
--- a/pipelines/folioRancher/folioScheduledProvisioning/createDailySnapshotEureka/Jenkinsfile
+++ b/pipelines/folioRancher/folioScheduledProvisioning/createDailySnapshotEureka/Jenkinsfile
@@ -15,8 +15,10 @@ import org.jenkinsci.plugins.workflow.libs.Library
 properties([
   buildDiscarder(logRotator(numToKeepStr: '30')),
   disableConcurrentBuilds(),
-  parameters([folioParameters.refreshParameters()]),
-  pipelineTriggers([parameterizedCron('''H 4 * * 1-5''')])
+  parameters([
+    folioParameters.platformBranch('PLATFORM_BRANCH', 'platform-lsp', ''),
+    folioParameters.refreshParameters()
+  ])
 ])
 
 
@@ -30,7 +32,7 @@ PodTemplates podTemplates = new PodTemplates(this)
 CreateNamespaceParameters namespace1 = new CreateNamespaceParameters.Builder()
   .clusterName('folio-etesting')
   .namespaceName('snapshot')
-  .platformBranch('snapshot')
+  .platformBranch(params.PLATFORM_BRANCH)
   .splitFiles(true)
   .ecsCCL(true)
   .build(this)
@@ -38,7 +40,7 @@ CreateNamespaceParameters namespace1 = new CreateNamespaceParameters.Builder()
 CreateNamespaceParameters namespace2 = new CreateNamespaceParameters.Builder()
   .clusterName('folio-etesting')
   .namespaceName('snapshot2')
-  .platformBranch('snapshot')
+  .platformBranch(params.PLATFORM_BRANCH)
   .splitFiles(true)
   .ecsCCL(true)
   .build(this)
@@ -100,7 +102,7 @@ ansiColor('xterm') {
 
     stage('Build name') {
       buildName "${createdEnv.getClusterName()}-${createdEnv.getNamespaceName()}.${env.BUILD_ID}"
-      buildDescription "Config: ${createdEnv.getConfigType()}"
+      buildDescription "Config: ${createdEnv.getConfigType()}\nPlatform branch: ${params.PLATFORM_BRANCH}"
     }
 
     spinUpNamespaces(createdEnv, eliminatedEnv)

--- a/pipelines/folioRancher/folioScheduledProvisioning/promoteDailySnapshotEureka/Jenkinsfile
+++ b/pipelines/folioRancher/folioScheduledProvisioning/promoteDailySnapshotEureka/Jenkinsfile
@@ -12,6 +12,7 @@ import org.jenkinsci.plugins.workflow.libs.Library
 
 @Field final String platformRepository = 'platform-lsp'
 @Field final String platformBranch = 'snapshot'
+@Field final String updateConfigPath = '.github/update-config.yml'
 @Field final String snapshotJobName = Constants.JENKINS_CREATE_DAILY_SNAPSHOT_EUREKA_JOB
 
 properties([
@@ -54,10 +55,28 @@ ansiColor('xterm') {
 }
 
 /**
+ * Resolve the update branch of a release branch from platform-lsp's own configuration, so the
+ * naming convention is declared in exactly one place. Read from master, which is where the
+ * release workflows read it from as well.
+ */
+String resolveUpdateBranch(String releaseBranch) {
+  Logger logger = new Logger(this, 'promoteDailySnapshotEureka')
+  String config = new GitHubClient(this).getFileContent('master', updateConfigPath, platformRepository)
+
+  if (!config) {
+    logger.error("Could not read ${updateConfigPath} from ${platformRepository}@master")
+  }
+
+  String format = readYaml(text: config)?.update_config?.update_branch_format
+  if (!format) {
+    logger.error("'update_config.update_branch_format' is missing from ${platformRepository} ${updateConfigPath}")
+  }
+
+  return format.replace('{0}', releaseBranch)
+}
+
+/**
  * Look up the open descriptor-update pull request for a platform-lsp release branch.
- *
- * The update branch name follows the `update_branch_format` declared in platform-lsp's
- * .github/update-config.yml, so the two have to stay in step.
  *
  * Returns a flat map of primitives rather than the raw API body, because the value is held
  * across stages and the pipeline's program state must serialize at every step boundary.
@@ -65,7 +84,7 @@ ansiColor('xterm') {
  */
 Map findOpenUpdatePr(String releaseBranch) {
   Map pullRequest = new GitHubClient(this)
-    .getOpenPullRequest(platformRepository, releaseBranch, "version-update/${releaseBranch}")
+    .getOpenPullRequest(platformRepository, releaseBranch, resolveUpdateBranch(releaseBranch))
 
   if (!pullRequest) {
     return [:]

--- a/pipelines/folioRancher/folioScheduledProvisioning/promoteDailySnapshotEureka/Jenkinsfile
+++ b/pipelines/folioRancher/folioScheduledProvisioning/promoteDailySnapshotEureka/Jenkinsfile
@@ -1,0 +1,95 @@
+#!groovy
+package folioRancher.folioScheduledProvisioning.promoteDailySnapshotEureka
+
+import groovy.transform.Field
+import org.folio.Constants
+import org.folio.jenkins.PodTemplates
+import org.folio.utilities.GitHubClient
+import org.folio.utilities.Logger
+import org.jenkinsci.plugins.workflow.libs.Library
+
+@Library('pipelines-shared-library') _
+
+@Field final String platformRepository = 'platform-lsp'
+@Field final String platformBranch = 'snapshot'
+@Field final String snapshotJobName = Constants.JENKINS_CREATE_DAILY_SNAPSHOT_EUREKA_JOB
+
+properties([
+  buildDiscarder(logRotator(numToKeepStr: '30')),
+  disableConcurrentBuilds(),
+  parameters([folioParameters.refreshParameters()]),
+  pipelineTriggers([parameterizedCron('''H 4 * * 1-5''')])
+])
+
+
+if (params.REFRESH_PARAMETERS) {
+  currentBuild.result = 'ABORTED'
+  return
+}
+
+PodTemplates podTemplates = new PodTemplates(this)
+
+ansiColor('xterm') {
+  podTemplates.rancherAgent {
+    Map updatePr = [:]
+
+    stage('Determination') {
+      updatePr = findOpenUpdatePr(platformBranch)
+      buildDescription(updatePr
+        ? "Queueing '${updatePr.branch}' (PR #${updatePr.number})"
+        : "No pending update. Deploying '${platformBranch}'")
+    }
+
+    if (updatePr) {
+      stage('Queue platform update') {
+        enqueueUpdatePr(updatePr)
+      }
+    } else {
+      stage('Deploy platform branch') {
+        folioTriggerJob.downStreamJob(snapshotJobName,
+          [string(name: 'PLATFORM_BRANCH', value: platformBranch)], true, true)
+      }
+    }
+  }
+}
+
+/**
+ * Look up the open descriptor-update pull request for a platform-lsp release branch.
+ *
+ * The update branch name follows the `update_branch_format` declared in platform-lsp's
+ * .github/update-config.yml, so the two have to stay in step.
+ *
+ * Returns a flat map of primitives rather than the raw API body, because the value is held
+ * across stages and the pipeline's program state must serialize at every step boundary.
+ * An empty map means the branch carries no pending update.
+ */
+Map findOpenUpdatePr(String releaseBranch) {
+  Map pullRequest = new GitHubClient(this)
+    .getOpenPullRequest(platformRepository, releaseBranch, "version-update/${releaseBranch}")
+
+  if (!pullRequest) {
+    return [:]
+  }
+
+  return [number: pullRequest.number as int,
+          nodeId: pullRequest.node_id as String,
+          branch: pullRequest.head.ref as String,
+          url   : pullRequest.html_url as String]
+}
+
+/**
+ * Add the update pull request to the merge queue of its base branch.
+ *
+ * GitHub owns the rest: it builds an immutable queue ref, holds the update branch locked while
+ * the deployment check runs against that ref, and merges only on success. A failed or timed-out
+ * check ejects the entry and leaves the release branch at its last validated state.
+ */
+void enqueueUpdatePr(Map updatePr) {
+  Logger logger = new Logger(this, 'promoteDailySnapshotEureka')
+
+  if (new GitHubClient(this).enqueuePullRequest(updatePr.nodeId)) {
+    logger.info("Queued ${updatePr.url}. GitHub will merge it once the deployment check passes.")
+  } else {
+    logger.error("Could not queue ${updatePr.url}. '${updatePr.branch}' stays unmerged.")
+  }
+}

--- a/src/org/folio/Constants.groovy
+++ b/src/org/folio/Constants.groovy
@@ -129,6 +129,7 @@ class Constants {
   static String FOLIO_SSH_GITHUB_URL = 'git@github.com:folio-org'
   static String FOLIO_GITHUB_REPOS_URL = 'https://api.github.com/repos/folio-org'
   static String FOLIO_GITHUB_RAW_URL = 'https://raw.githubusercontent.com/folio-org'
+  static String GITHUB_GRAPHQL_URL = 'https://api.github.com/graphql'
   static String CI_ROOT_DOMAIN = 'ci.folio.org'
   static String ROUTE53_CI_HOSTED_ZONE_ID = 'Z3T7T50VQ846GQ'
   static String FOLIO_OPEN_SEARCH_URL = 'https://vpc-folio-opensearch-yq77h7fbng7nq6esvgparhiida.us-west-2.es.amazonaws.com'
@@ -207,6 +208,7 @@ class Constants {
 
   static final String JENKINS_FOLIO_RANCHER_FOLDER = '/folioRancher'
   static final String JENKINS_CYPRESS_ECS_JOB = "/folioScheduledTesting/runNightlyCypressEurekaTestsECS"
+  static final String JENKINS_CREATE_DAILY_SNAPSHOT_EUREKA_JOB = "/folioScheduledProvisioning/createDailySnapshotEureka"
 
   static final String JENKINS_CREATE_NAMESPACE_FROM_BRANCH_JOB = "$JENKINS_FOLIO_RANCHER_FOLDER/manageNamespace/createNamespaceFromBranch"
 

--- a/src/org/folio/utilities/GitHubClient.groovy
+++ b/src/org/folio/utilities/GitHubClient.groovy
@@ -16,7 +16,8 @@ class GitHubClient {
 
   GitHubClient(Object context) {
     this.logger = new Logger(context, this.getClass().getCanonicalName())
-    this.restClient = new RestClient(context, true)
+    // Debug mode logs the assembled curl command, which carries the bearer token in clear text.
+    this.restClient = new RestClient(context)
     this.gitHubToken = SystemCredentialsProvider.getInstance().getStore()
       .getCredentials(Domain.global()).find { it.getId().equals(GITHUB_TOKEN_CREDENTIAL_ID) }.getSecret()
   }
@@ -142,6 +143,57 @@ class GitHubClient {
     } catch (Exception e) {
       logger.warning("Failed to get file content for ${repository}/${filePath}@${sha}: ${e.getMessage()}")
       return ''
+    }
+  }
+
+  /**
+   * Fetch the open pull request from headBranch into baseBranch.
+   * Returns an empty map when none is open, or on any lookup failure.
+   */
+  Map getOpenPullRequest(String repository, String baseBranch, String headBranch) {
+    String url = "${Constants.FOLIO_GITHUB_REPOS_URL}/${repository}/pulls" +
+      "?state=open&base=${baseBranch}&head=${Constants.FOLIO_ORG}:${headBranch}"
+    Map<String, String> headers = authorizedHeaders()
+
+    try {
+      def response = restClient.get(url, headers)
+      if (response.responseCode >= 200 && response.responseCode < 300) {
+        return (response.body as List)?.getAt(0) as Map ?: [:]
+      } else {
+        logger.warning("GitHub API returned ${response.responseCode} for pull request lookup: ${url}")
+        return [:]
+      }
+    } catch (Exception e) {
+      logger.warning("Failed to look up pull request ${repository} ${headBranch} -> ${baseBranch}: ${e.getMessage()}")
+      return [:]
+    }
+  }
+
+  /**
+   * Add a pull request to the merge queue of its base branch, identified by its GraphQL node id.
+   * Returns the merge queue entry, or an empty map when GitHub declined.
+   *
+   * Enqueueing exists only in the GraphQL API, which answers 200 with an `errors` array instead
+   * of an HTTP error code, so the body has to be inspected rather than the status.
+   */
+  Map enqueuePullRequest(String pullRequestId) {
+    String mutation = 'mutation($id: ID!) { enqueuePullRequest(input: {pullRequestId: $id}) ' +
+      '{ mergeQueueEntry { id position state } } }'
+    Map<String, String> headers = authorizedHeaders()
+
+    try {
+      def response = restClient.post(Constants.GITHUB_GRAPHQL_URL,
+        [query: mutation, variables: [id: pullRequestId]], headers)
+      Map body = response.body as Map ?: [:]
+
+      if (body.errors) {
+        logger.warning("GitHub declined to enqueue ${pullRequestId}: ${body.errors}")
+        return [:]
+      }
+      return body.data?.enqueuePullRequest?.mergeQueueEntry as Map ?: [:]
+    } catch (Exception e) {
+      logger.warning("Failed to enqueue ${pullRequestId}: ${e.getMessage()}")
+      return [:]
     }
   }
 


### PR DESCRIPTION
## Why

`platform-lsp@snapshot` receives descriptor updates by direct commit. If the snapshot environment then fails to deploy, the branch has already advanced and the platform state no longer reflects anything that ever worked — recovery is manual.

The ticket originally proposed a `platform-descriptor.tmp.json` staging file. That is dropped. RANCHER-3069 moved the snapshot cadence onto the release path, where hourly updates already accumulate on `version-update/snapshot` behind one long-lived PR, so the safer mechanism is to gate that PR on a real deployment rather than invent a staging file.

## Mechanism

Once nightly, the update PR is added to a **GitHub merge queue** on `snapshot`. GitHub builds an immutable `gh-readonly-queue/...` ref, the snapshot deployment validates exactly that ref as a required status check, and GitHub merges on success or ejects on failure. `snapshot` only ever advances to a state that deployed green.

This PR is the Jenkins half. The GitHub half is RANCHER-3118 (deployment check workflow) and RANCHER-3119 (ruleset provisioning).

Why a merge queue rather than a lock of our own: GitHub locks the update branch for the duration and enforces the check timeout server-side, so no lease, heartbeat or TTL is needed anywhere. Both behaviours were verified against the live API before writing this — see the spike results on RANCHER-2519.

## Changes

**`src/org/folio/utilities/GitHubClient.groovy`**
- `getOpenPullRequest(repository, baseBranch, headBranch)` — finds the open update PR. The `head` filter needs `owner:ref` form. Returns `[:]` on miss or failure, matching the class's existing style; "no PR" is a normal outcome that means "deploy the branch as-is".
- `enqueuePullRequest(nodeId)` — adds a PR to the merge queue. This exists only in GraphQL, which answers `200` with an `errors` array rather than an HTTP error, so the body is inspected instead of the status code. The mutation is the one proven against the live API during the spike.
- Dropped the `debug` flag on the `RestClient` construction. With it enabled, `RestClient` logs the assembled curl command, which carries `Authorization: Bearer <token>` in clear text — and the token comes from `SystemCredentialsProvider` rather than `withCredentials`, so Jenkins does not mask it. Unrelated to the feature but in the file being touched, and it affects every existing `GitHubClient` caller.

**`src/org/folio/Constants.groovy`** — `GITHUB_GRAPHQL_URL` and `JENKINS_CREATE_DAILY_SNAPSHOT_EUREKA_JOB`.

**`createDailySnapshotEureka/Jenkinsfile`** — gains a `PLATFORM_BRANCH` parameter via the existing `folioParameters.platformBranch()` helper, threaded into both `CreateNamespaceParameters` builders in place of the hardcoded `'snapshot'`, and surfaced in the build description. The cron trigger moves to the new umbrella job. The empty `reference` argument is deliberate: the helper defaults to referencing a `PLATFORM` parameter, which this job does not have, and `branchWithRef` already establishes `""` as the shape for an unreferenced select.

**`promoteDailySnapshotEureka/Jenkinsfile`** (new) — takes over the `H 4 * * 1-5` cron. If an open update PR exists it queues it and finishes, letting GitHub drive from there. If not, it triggers `createDailySnapshotEureka` against `snapshot` and waits, so blue/green rotation and the `build-date` labels keep working on quiet nights. Two separate paths rather than a flag.

The update branch is not hardcoded. `resolveUpdateBranch` reads `update_config.update_branch_format` out of platform-lsp's `.github/update-config.yml` and substitutes the release branch, so the naming convention stays declared in one place and renaming it needs no change here. It reads from `master` deliberately: that is where kitfox's `get-update-config` reads it from too (`branch: master` is hardcoded there), so `master`'s copy is the single source of truth regardless of which branch is being updated — and `snapshot` has no `.github/` directory at all. A missing file or missing key fails the build rather than falling back to a default, because a wrong guess would silently find no PR, fall through to a plain deploy, and stop promotion without anyone noticing.

## Notes for reviewers

**This is inert until the platform-lsp side lands.** While RANCHER-3069 keeps the `snapshot` entry disabled there is no `version-update/snapshot` PR, so the umbrella always takes the fall-through path and deploys plain `snapshot` — the same behaviour as today, just triggered one job further up.

**`findOpenUpdatePr` returns a flat map of primitives, not the raw API body.** The raw response is nested `LazyMap`, and the value is held across stages where CPS must serialize program state at every step boundary.

**Ref handling needed no changes.** Everything downstream already resolves an arbitrary ref, including ones containing slashes: `folioTriggerJob` passes `PLATFORM_BRANCH` as a string, `folioDefault.getPlatformDescriptor` fetches over raw.githubusercontent, and `common.getLastCommitHash` / `folioUI._checkout` use the branches API. Both hosts were confirmed to resolve a two-slash ref of the `gh-readonly-queue/<base>/pr-N-<sha>` shape. Because the queue ref is immutable, the existing downstream re-resolution of branch HEAD is correct as it stands — no commit SHA has to be threaded through the job chain.

## Deployment prerequisite

The cron moves off `createDailySnapshotEureka` onto `promoteDailySnapshotEureka`, so **the new job has to exist in Jenkins before this merges**, or the nightly snapshot silently stops running.

## Related

- RANCHER-2519 — this PR
- RANCHER-3118 — config-driven deployment check for platform-lsp merge groups
- RANCHER-3119 — declarative branch-ruleset provisioning for platform-lsp
- RANCHER-3069 — enables the `snapshot` entry with PR-based delivery
